### PR TITLE
Fixed overflow of sidebar and navbar on main screen.

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,10 +1,15 @@
 <template>
-  <div class="flex text-gray-900 h-screen antialiased">
+  <div class="flex text-gray-900 h-screen antialiased overflow-y-hidden">
     <UploadTracker v-if="showUploadTracker" />
-    <div class="h-full max-h-full w-full max-w-full flex flex-col"
-      :class="{ 'sm:bg-gray-50': $route.meta.isPublicRoute }">
-      <Navbar v-if="isLoggedIn && !isHybridRoute" :mobileSidebarIsOpen="showMobileSidebar"
-        @toggleMobileSidebar="showMobileSidebar = !showMobileSidebar" />
+    <div
+      class="h-full max-h-full w-full max-w-full flex flex-col"
+      :class="{ 'sm:bg-gray-50': $route.meta.isPublicRoute }"
+    >
+      <Navbar
+        v-if="isLoggedIn && !isHybridRoute"
+        :mobileSidebarIsOpen="showMobileSidebar"
+        @toggleMobileSidebar="showMobileSidebar = !showMobileSidebar"
+      />
       <div v-if="isLoggedIn && !isHybridRoute" class="flex h-full">
         <MobileSidebar v-model="showMobileSidebar" />
         <div class="px-3 border-r hidden md:py-4 md:block">
@@ -22,11 +27,11 @@
   </div>
 </template>
 <script>
-import Navbar from '@/components/Navbar.vue'
-import Sidebar from '@/components/Sidebar.vue'
-import InfoSidebar from '@/components/InfoSidebar.vue'
-import MobileSidebar from '@/components/MobileSidebar.vue'
-import UploadTracker from '@/components/UploadTracker.vue'
+import Navbar from '@/components/Navbar.vue';
+import Sidebar from '@/components/Sidebar.vue';
+import InfoSidebar from '@/components/InfoSidebar.vue';
+import MobileSidebar from '@/components/MobileSidebar.vue';
+import UploadTracker from '@/components/UploadTracker.vue';
 
 export default {
   name: 'App',
@@ -40,27 +45,27 @@ export default {
   data() {
     return {
       showMobileSidebar: false,
-    }
+    };
   },
   computed: {
     isLoggedIn() {
-      return this.$store.getters.isLoggedIn
+      return this.$store.getters.isLoggedIn;
     },
     isHybridRoute() {
-      return this.$route.meta.isHybridRoute
+      return this.$route.meta.isHybridRoute;
     },
     showUploadTracker() {
-      return this.isLoggedIn && this.$store.state.uploads.length > 0
+      return this.isLoggedIn && this.$store.state.uploads.length > 0;
     },
     showInfoSidebar() {
-      return this.$store.state.showInfo && this.$store.state.entityInfo
+      return this.$store.state.showInfo && this.$store.state.entityInfo;
     },
   },
   watch: {
-    '$route'() {
-      this.$store.commit('setEntityInfo', null)
-      this.$store.commit('setShowInfo', false)
-    }
+    $route() {
+      this.$store.commit('setEntityInfo', null);
+      this.$store.commit('setShowInfo', false);
+    },
   },
-}
+};
 </script>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,15 +1,10 @@
 <template>
   <div class="flex text-gray-900 h-screen antialiased overflow-y-hidden">
     <UploadTracker v-if="showUploadTracker" />
-    <div
-      class="h-full max-h-full w-full max-w-full flex flex-col"
-      :class="{ 'sm:bg-gray-50': $route.meta.isPublicRoute }"
-    >
-      <Navbar
-        v-if="isLoggedIn && !isHybridRoute"
-        :mobileSidebarIsOpen="showMobileSidebar"
-        @toggleMobileSidebar="showMobileSidebar = !showMobileSidebar"
-      />
+    <div class="h-full max-h-full w-full max-w-full flex flex-col"
+      :class="{ 'sm:bg-gray-50': $route.meta.isPublicRoute }">
+      <Navbar v-if="isLoggedIn && !isHybridRoute" :mobileSidebarIsOpen="showMobileSidebar"
+        @toggleMobileSidebar="showMobileSidebar = !showMobileSidebar" />
       <div v-if="isLoggedIn && !isHybridRoute" class="flex h-full">
         <MobileSidebar v-model="showMobileSidebar" />
         <div class="px-3 border-r hidden md:py-4 md:block">
@@ -27,11 +22,11 @@
   </div>
 </template>
 <script>
-import Navbar from '@/components/Navbar.vue';
-import Sidebar from '@/components/Sidebar.vue';
-import InfoSidebar from '@/components/InfoSidebar.vue';
-import MobileSidebar from '@/components/MobileSidebar.vue';
-import UploadTracker from '@/components/UploadTracker.vue';
+import Navbar from '@/components/Navbar.vue'
+import Sidebar from '@/components/Sidebar.vue'
+import InfoSidebar from '@/components/InfoSidebar.vue'
+import MobileSidebar from '@/components/MobileSidebar.vue'
+import UploadTracker from '@/components/UploadTracker.vue'
 
 export default {
   name: 'App',
@@ -45,27 +40,27 @@ export default {
   data() {
     return {
       showMobileSidebar: false,
-    };
+    }
   },
   computed: {
     isLoggedIn() {
-      return this.$store.getters.isLoggedIn;
+      return this.$store.getters.isLoggedIn
     },
     isHybridRoute() {
-      return this.$route.meta.isHybridRoute;
+      return this.$route.meta.isHybridRoute
     },
     showUploadTracker() {
-      return this.isLoggedIn && this.$store.state.uploads.length > 0;
+      return this.isLoggedIn && this.$store.state.uploads.length > 0
     },
     showInfoSidebar() {
-      return this.$store.state.showInfo && this.$store.state.entityInfo;
+      return this.$store.state.showInfo && this.$store.state.entityInfo
     },
   },
   watch: {
-    $route() {
-      this.$store.commit('setEntityInfo', null);
-      this.$store.commit('setShowInfo', false);
-    },
+    '$route'() {
+      this.$store.commit('setEntityInfo', null)
+      this.$store.commit('setShowInfo', false)
+    }
   },
-};
+}
 </script>


### PR DESCRIPTION
Before:
Fixed header and navbar used to overflow the screen > h-screen. Hence creating two scrollbars which made navigation harder.

After:
Added overflow-y-hidden to keep view fixed and stop scrolling. Only dynamic route content is now scrollable.
