### PR TITLE
Suggested improvements to the searchPopup.vue component

### DIFF
--- a/drive/api/permissions.py
+++ b/drive/api/permissions.py
@@ -5,6 +5,7 @@ import frappe
 from pypika import Order
 from drive.api.files import get_entity
 from drive.utils.files import get_user_directory
+from drive.api.tags import get_entity_tags
 
 
 @frappe.whitelist()
@@ -122,6 +123,11 @@ def get_all_my_entities(fields=None):
     shared_entities = get_shared_with_me(get_all=True)
 
     all_entities = shared_entities + my_entities
+    
+    if 'tags' in fields:
+        for x in all_entities:
+            x['tags'] = get_entity_tags(x['name'])
+            
     return list({x['name']: x for x in all_entities}.values())
 
 

--- a/frontend/src/assets/images/icons/tag.svg
+++ b/frontend/src/assets/images/icons/tag.svg
@@ -1,0 +1,8 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="m100 50l-33 50h-67v-100h68z" fill="#9013fe"/>
+<path d="m10.5 64.9v-5h45v5z" fill="white"/>
+<path d="m10.5 43.9v-5h45v5z" fill="white"/>
+<path d="m42.5 29.9h5v45h-5z" fill="white"/>
+<path d="m19.5 29.9h5v45h-5z" fill="white"/>
+<path d="m83 56c-2.8 0-5-2.5-5-5.5 0-3 2.2-5.5 5-5.5 2.8 0 5 2.5 5 5.5 0 3-2.2 5.5-5 5.5z" fill="white"/>
+</svg>

--- a/frontend/src/components/SearchPopup.vue
+++ b/frontend/src/components/SearchPopup.vue
@@ -1,60 +1,86 @@
 <template>
-  <div v-on-outside-click="closePopup" :class="divClass">
-    <Input
-      v-model="search"
-      icon-left="search"
-      type="text"
-      :class="{ 'bg-white focus:bg-white': isOpen }"
-      placeholder="Search"
-      @focus="openPopup"
-      @input="($event) => (search = $event)" />
-    <div v-if="isOpen" class="mt-3">
-      <div v-if="showEntities">
-        <div
-          v-for="entity in filteredEntities"
-          :key="entity"
-          class="flex flex-row cursor-pointer hover:bg-gray-100 rounded-xl py-2 px-3"
-          @click="openEntity(entity)">
-          <div class="flex grow items-center">
-            <img
-              :src="
-                getIconUrl(
-                  entity.is_group ? 'folder' : formatMimeType(entity.mime_type)
-                )
-              "
-              class="w-6 mr-4" />
-            <div>
-              <div class="text-lg text-gray-900 font-medium truncate">
-                {{ entity.title }}
+  <div v-on-outside-click="closePopup" :class="div0Class">
+    <div :class="divClass">
+      <Input
+        v-model="search"
+        icon-left="search"
+        type="text"
+        :class="{ 'bg-white focus:bg-white': isOpen }"
+        placeholder="Search"
+        @focus="openPopup"
+        @input="($event) => (search = $event)" />
+      <div v-if="isOpen" >
+
+        <div class="my-2 grid gap-2 grid-cols-2 border shadow-md p-2 rounded-2xl max-w-[50%]">
+          <div
+            v-for="by in filterBy"
+            :key="by"
+            class="w-25 border rounded-lg flex flex-row cursor-pointer"
+            :class="{ 'bg-gray-300': selectedFilterBy[by.imgSrc] }"
+            @click="filteredBy()">
+            <div class="md:flex grow items-center">
+              <img :src="getIconUrl(by.imgSrc)" class="h-[22px] my-2 ml-2" />
+              <div class="text-sm text-gray-700 text-center my-2 ml-2">
+                {{ by.title }}
               </div>
-              <div class="text-[13px] text-gray-600">{{ entity.owner }}</div>
             </div>
           </div>
-          <div class="text-[13px] text-gray-600 whitespace-nowrap my-auto">
-            {{ entity.modified }}
+        </div>
+
+        <div v-if="showEntities" class="overflow-y-scroll max-h-80">
+          <div
+            v-for="entity in filteredEntities"
+            :key="entity"
+            class="md:flex flex-row cursor-pointer hover:bg-gray-200 rounded-xl py-2 px-3"
+            @click="openEntity(entity)">
+            <div class="md:flex grow items-center">
+              <img
+                :src="
+                  getIconUrl(
+                    entity.is_group ? 'folder' : formatMimeType(entity.mime_type)
+                  )
+                "
+                class="w-6 mr-4" />
+              <div>
+                <div class="text-lg text-gray-900 font-medium truncate">
+                  {{ entity.title }}
+                </div>
+                <div v-if="selectedFilterBy['tag'] && entity.tags.length">
+                  <span v-for="tag in entity.tags" :key="tag" >
+                    <Badge :color="tag.color" > {{ `• ${tag.title}` }} </Badge>
+                  </span>
+                </div>
+                <div v-else class="text-[13px] text-gray-600">{{ entity.owner }}</div>
+              </div>
+            </div>
+            <div class="text-[13px] text-gray-600 whitespace-nowrap my-auto">
+              {{ entity.modified }}
+            </div>
           </div>
         </div>
-      </div>
-      <div v-else class="mx-2.5 mb-2.5 mt-6 space-x-2.5 flex">
-        <div
-          v-for="item in filterItems"
-          :key="item"
-          class="w-28 border rounded-lg flex flex-col cursor-pointer"
-          :class="{ 'bg-gray-200': selectedFilterItems[item.imgSrc] }"
-          @click="
-            selectedFilterItems[item.imgSrc] = !selectedFilterItems[item.imgSrc]
-          ">
-          <img :src="getIconUrl(item.imgSrc)" class="h-[22px] mt-3.5 mb-3" />
-          <div class="text-sm text-gray-700 text-center mb-2">
-            {{ item.title }}
+
+        <div v-else class="grid gap-2 grid-cols-3 grid-rows-2 md:grid-cols-6 md:grid-rows-1">
+          <div
+            v-for="item in filterItems"
+            :key="item"
+            class="w-25 border rounded-lg flex flex-col cursor-pointer"
+            :class="{ 'bg-gray-200': selectedFilterItems[item.imgSrc] }"
+            @click="
+              selectedFilterItems[item.imgSrc] = !selectedFilterItems[item.imgSrc]
+            ">
+            <img :src="getIconUrl(item.imgSrc)" class="h-[22px] mt-3.5 mb-3" />
+            <div class="text-sm text-gray-700 text-center mb-2">
+              {{ item.title }}
+            </div>
           </div>
         </div>
+
       </div>
     </div>
   </div>
 </template>
 <script>
-import { Input } from "frappe-ui";
+import { Input, Badge } from "frappe-ui"
 import { formatSize, formatDate } from "@/utils/format";
 import getFilteredEntities from "../utils/fuzzySearcher";
 import { formatMimeType } from "@/utils/format";
@@ -63,7 +89,7 @@ import getIconUrl from "@/utils/getIconUrl";
 export default {
   name: "SearchPopup",
   components: {
-    Input,
+    Input, Badge,
   },
   emits: ["openEntity"],
   setup() {
@@ -87,6 +113,10 @@ export default {
           imgSrc: "pdf",
         },
         {
+          title: "Image",
+          imgSrc: "image",
+        },
+        {
           title: "Video",
           imgSrc: "video",
         },
@@ -96,25 +126,73 @@ export default {
         },
       ],
       selectedFilterItems: {
-        doc: false,
-        spreadsheet: false,
-        pdf: false,
-        video: false,
-        folder: false,
+        doc: true,
+        spreadsheet: true,
+        pdf: true,
+        image: true,
+        video: true,
+        folder: true,
+        fullSelection: function() { 
+          return (this.doc && this.spreadsheet && this.pdf && this.image && this.video && this.folder);
+        },
+      },
+      filterBy: [
+        {
+          title: "Title",
+          imgSrc: "unknown",
+        },
+        {
+          title: "Tag",
+          imgSrc: "tag",
+        },
+      ],
+      selectedFilterBy: {
+        unknown: true,
+        tag: false,
       },
     };
   },
   computed: {
+    div0Class() {
+      if (!this.isOpen)
+        return "w-[100px] md:w-[200px]";
+      return "w-[120px] md:w-[500px] lg:w-[620px]";
+    },
     divClass() {
       if (!this.isOpen)
-        return "w-[200px] rounded-lg bg-white transition-all duration-[600ms]";
-      return "w-[620px] border shadow-md p-2 rounded-2xl bg-white transition-all duration-[600ms]";
+        return "w-[100px] md:w-[200px] rounded-lg bg-white transition-all duration-[600ms]";
+      return "w-[280px] md:w-[620px] mt-8 lg:mt-0 place-self-center border shadow-md p-2 rounded-2xl bg-white transition-all duration-[600ms]";
     },
     userId() {
       return this.$store.state.auth.user_id;
     },
     filteredEntities() {
-      return getFilteredEntities(this.search, this.$resources.entities.data);
+      if (this.selectedFilterBy['tag']) {
+        return this.prefilter;
+      }
+      if (this.selectedFilterItems.fullSelection()) {
+        return getFilteredEntities(this.search, this.$resources.entities.data);
+      } else {
+        return getFilteredEntities(this.search, this.prefilter);
+      }
+    },
+    prefilter() {
+      return this.$resources.entities.data
+        .filter((t) => (
+          ((t.is_group && this.selectedFilterItems["folder"]) || 
+            ((!t.is_group) && 
+              ((this.selectedFilterItems["doc"] && t.mime_type.search(/text/) > -1)
+                || (this.selectedFilterItems["spreadsheet"] && t.mime_type.search(/vnd/) > -1)
+                || (this.selectedFilterItems["pdf"] && t.mime_type.search(/pdf/) > -1 ) 
+                || (this.selectedFilterItems["image"] && t.mime_type.search(/image/) > -1) 
+                || (this.selectedFilterItems["video"] && t.mime_type.search(/video/) > -1) 
+              )
+            )
+          ) && 
+          ((!this.selectedFilterBy['tag']) || 
+            t.strtags.search("#" + this.search.toLowerCase()) > -1
+          )
+        ));
     },
     showEntities() {
       return this.search.length > 0;
@@ -123,6 +201,8 @@ export default {
   methods: {
     openEntity(entity) {
       this.isOpen = false;
+      let folder = this.$resources.entities.data.filter((t) => (t.name === entity.parent_drive_entity));
+      if (folder[0].is_group) {this.$emit("openEntity", folder[0]);}
       this.$emit("openEntity", entity);
     },
     openPopup() {
@@ -132,11 +212,19 @@ export default {
     closePopup() {
       this.isOpen = false;
     },
+    filteredBy() {
+      this.selectedFilterBy['tag'] = !this.selectedFilterBy['tag'];
+      this.selectedFilterBy['unknown'] = !this.selectedFilterBy['unknown'];
+    },
   },
   resources: {
     entities() {
       return {
         url: "drive.api.permissions.get_all_my_entities",
+        params: { 
+          fields: ['name', 'title', 'is_group','owner', 'modified', 'file_size', 'mime_type', 'tags',
+          'parent_drive_entity', ] 
+        },
         onSuccess(data) {
           this.$resources.entities.error = null;
           data.forEach((entity) => {
@@ -147,6 +235,10 @@ export default {
             entity.modified = formatDate(entity.modified);
             entity.creation = formatDate(entity.creation);
             entity.owner = entity.owner === this.userId ? "me" : entity.owner;
+            entity.strtags = "";
+            for (let i = 0; i < entity.tags.length; i++) {
+              entity.strtags += '#' + entity.tags[i]['title'].toLowerCase();
+            }
           });
         },
       };


### PR DESCRIPTION
1.- **Adapt the design to mobile devices**. Prevent it from overflowing the screen.
2.- **Allow search on specific types of entities**. Make existing entity type images interactive and add the image type.
3.- **Allow the search by tags**. The user will be able to search by the title or by the tags of the entities. You will be able to see the labels of each entity.
4.- **Locate the selected entity in its folder, if the user has access to that folde**r. Currently only the file is displayed and sometimes the file type is not displayable. When the number of folders and files is large, it does not provide enough information to locate the selected entity. I would like that after the visualization the user would find the selected entity in the folder and could perform any new action, but I have not managed to develop this yet, I just leave it inside the folder.

By default it will search as before. When the user does not indicate otherwise, it will search for the first 5 entities whose title includes the character string indicated in the search. But if you search by tags you will see all the entities that contain the tag. The component will present a vertical scroll when the displayed entities exceed the size of the component.

This proposal requires making a change to drive/drive/api/permissions.py so that get_all_my_entities includes the labels when requested in the fields parameter.

It is also necessary an icon that represents the search by tags, I have designed a tag.svg that I attach.

![image](https://user-images.githubusercontent.com/29335418/230720659-16eb8e09-4050-411f-9d76-982ae9f85f16.png)
![searhPopupPc1](https://user-images.githubusercontent.com/29335418/230721192-2596d1db-69b4-4820-bf21-dc87ba3ee2b2.JPG)

![searhPopupPc2](https://user-images.githubusercontent.com/29335418/230721235-27a0d47e-474e-4d07-9b6b-96ad0f70b21d.JPG)

I thank you for dedicating your time to study this proposal for change.