### PR TITLE
feat: New Role Drive User

### DIFF
--- a/drive/drive/doctype/drive_document/drive_document.json
+++ b/drive/drive/doctype/drive_document/drive_document.json
@@ -43,6 +43,15 @@
       "role": "All",
       "share": 1,
       "write": 1
+    },
+    {
+      "create": 1,
+      "delete": 1,
+      "export": 1,
+      "read": 1,
+      "role": "Drive User",
+      "share": 1,
+      "write": 1
     }
   ],
   "sort_field": "modified",

--- a/drive/drive/doctype/drive_entity/drive_entity.json
+++ b/drive/drive/doctype/drive_entity/drive_entity.json
@@ -169,6 +169,15 @@
       "role": "All",
       "share": 1,
       "write": 1
+    },
+    {
+      "create": 1,
+      "delete": 1,
+      "export": 1,
+      "read": 1,
+      "role": "Drive User",
+      "share": 1,
+      "write": 1
     }
   ],
   "sort_field": "modified",

--- a/drive/drive/doctype/drive_favourite/drive_favourite.json
+++ b/drive/drive/doctype/drive_favourite/drive_favourite.json
@@ -43,6 +43,15 @@
       "role": "All",
       "share": 1,
       "write": 1
+    },
+    {
+      "create": 1,
+      "delete": 1,
+      "export": 1,
+      "read": 1,
+      "role": "Drive User",
+      "share": 1,
+      "write": 1
     }
   ],
   "sort_field": "modified",

--- a/drive/drive/doctype/drive_tag/drive_tag.json
+++ b/drive/drive/doctype/drive_tag/drive_tag.json
@@ -40,6 +40,15 @@
       "role": "System Manager",
       "share": 1,
       "write": 1
+    },
+    {
+      "create": 1,
+      "delete": 1,
+      "export": 1,
+      "read": 1,
+      "role": "Drive User",
+      "share": 1,
+      "write": 1
     }
   ],
   "sort_field": "modified",

--- a/drive/fixtures/role.json
+++ b/drive/fixtures/role.json
@@ -1,0 +1,23 @@
+[
+  {
+    "bulk_actions": 0,
+    "dashboard": 0,
+    "desk_access": 0,
+    "disabled": 0,
+    "docstatus": 0,
+    "doctype": "Role",
+    "form_sidebar": 0,
+    "home_page": null,
+    "is_custom": 0,
+    "list_sidebar": 0,
+    "modified": "2023-07-28 21:40:58.081485",
+    "name": "Drive User",
+    "notifications": 0,
+    "restrict_to_domain": null,
+    "role_name": "Drive User",
+    "search_bar": 0,
+    "timeline": 0,
+    "two_factor_auth": 0,
+    "view_switcher": 0
+  }
+]

--- a/drive/hooks.py
+++ b/drive/hooks.py
@@ -116,6 +116,11 @@ home_page = "drive"
 # 	}
 # }
 
+
+fixtures = [
+    {"dt": "Role", "filters": [["role_name", "like", "Drive %"]]}
+]
+
 # Scheduled Tasks
 # ---------------
 


### PR DESCRIPTION
feat: New Role Drive User with perms only to drive entities...
Yet to make `Drive User` the only role applies when new User is created