### PR TITLE
feat/fix: thumbnails now are stored on the filesystem

### DIFF
--- a/drive/api/files.py
+++ b/drive/api/files.py
@@ -10,7 +10,14 @@ import uuid
 import mimetypes
 import hashlib
 import json
-from drive.utils.files import get_user_directory, create_user_directory, get_new_title, get_user_thumbnails_directory, create_user_thumbnails_directory, create_thumbnail
+from drive.utils.files import (
+    get_user_directory,
+    create_user_directory,
+    get_new_title,
+    get_user_thumbnails_directory,
+    create_user_thumbnails_directory,
+    create_thumbnail,
+)
 from drive.locks.distributed_lock import DistributedLock
 from datetime import date, timedelta
 
@@ -68,6 +75,7 @@ def create_document_entity(title, content, parent=None):
     if parent == user_directory.name:
         drive_entity.share(frappe.session.user, write=1, share=1)
     return drive_entity
+
 
 @frappe.whitelist()
 def upload_file(fullpath=None, parent=None):
@@ -151,9 +159,21 @@ def upload_file(fullpath=None, parent=None):
             drive_entity.insert()
             if parent == user_directory.name:
                 drive_entity.share(frappe.session.user, write=1, share=1)
-            frappe.enqueue(create_thumbnail,queue="default",timeout=None,now=True,entity_name=name,path=path,mime_type=mime_type,)
+            
+            if(mime_type.startswith("image") or mime_type.startswith("video")):
+                frappe.enqueue(
+                    create_thumbnail,
+                    queue="default",
+                    timeout=None,
+                    now=True,
+                    #will set to false once reactivity in new UI is solved 
+                    entity_name=name,
+                    path=path,
+                    mime_type=mime_type,
+                )
             return drive_entity
-        
+
+
 @frappe.whitelist()
 def create_folder(title, parent=None):
     """
@@ -321,17 +341,20 @@ def list_folder_contents(entity_name=None, order_by="modified", is_active=1):
         frappe.throw("Specified folder has been trashed by the owner")
     share_every_perm = False
     if frappe.db.exists(
-                {
-                    "doctype": "DocShare",
-                    "share_doctype": "Drive Entity",
-                    "share_name": entity_name,
-                    "everyone": 1,
-                }
-            ):
-                share_every_perm = True
+        {
+            "doctype": "DocShare",
+            "share_doctype": "Drive Entity",
+            "share_name": entity_name,
+            "everyone": 1,
+        }
+    ):
+        share_every_perm = True
     if not share_every_perm:
         if not frappe.has_permission(
-            doctype="Drive Entity", doc=entity_name, ptype="read", user=frappe.session.user
+            doctype="Drive Entity",
+            doc=entity_name,
+            ptype="read",
+            user=frappe.session.user,
         ):
             frappe.throw(
                 "Cannot access folder due to insufficient permissions",

--- a/drive/api/thumbnail_generator.py
+++ b/drive/api/thumbnail_generator.py
@@ -9,8 +9,14 @@ from werkzeug.wsgi import wrap_file
 from werkzeug.utils import secure_filename
 from drive.utils.files import get_user_directory, create_user_directory, get_new_title
 from drive.locks.distributed_lock import DistributedLock
-from drive.utils.files import get_user_directory, create_user_directory, get_new_title, get_user_thumbnails_directory, create_user_thumbnails_directory, create_thumbnail
-import cv2
+from drive.utils.files import (
+    get_user_directory,
+    create_user_directory,
+    get_new_title,
+    get_user_thumbnails_directory,
+    create_user_thumbnails_directory,
+    create_thumbnail,
+)
 
 @frappe.whitelist(allow_guest=True)
 def create_image_thumbnail(entity_name):
@@ -26,19 +32,22 @@ def create_image_thumbnail(entity_name):
     flag = False
     for z_entity_name in entity_ancestors:
         result = frappe.db.exists(
-                {
-                    "doctype": "DocShare",
-                    "share_doctype": "Drive Entity",
-                    "share_name": z_entity_name,
-                    "everyone": 1,
-                }
-            )
+            {
+                "doctype": "DocShare",
+                "share_doctype": "Drive Entity",
+                "share_name": z_entity_name,
+                "everyone": 1,
+            }
+        )
         if result:
             flag = True
             break
     if not flag:
         if not frappe.has_permission(
-            doctype="Drive Entity", doc=entity_name, ptype="read", user=frappe.session.user
+            doctype="Drive Entity",
+            doc=entity_name,
+            ptype="read",
+            user=frappe.session.user,
         ):
             raise frappe.PermissionError("You do not have permission to view this file")
     with DistributedLock(drive_entity.path, exclusive=False):
@@ -52,17 +61,20 @@ def create_image_thumbnail(entity_name):
             response.headers.set("Content-Disposition", "inline", filename=entity_name)
         else:
             user_thumbnails_directory = get_user_thumbnails_directory()
-            thumbnail_getpath= Path(user_thumbnails_directory,entity_name)
+            thumbnail_getpath = Path(user_thumbnails_directory, entity_name)
             with open(str(thumbnail_getpath) + ".thumbnail", "rb") as file:
                 thumbnail_data = BytesIO(file.read())
             response = Response(
-                wrap_file(frappe.request.environ,thumbnail_data),
+                wrap_file(frappe.request.environ, thumbnail_data),
                 direct_passthrough=True,
             )
             response.headers.set("Content-Type", "image/jpeg")
-            response.headers.set("Content-Disposition", "inline",filename=entity_name)
-            frappe.cache().set_value(entity_name,)
+            response.headers.set("Content-Disposition", "inline", filename=entity_name)
+            frappe.cache().set_value(
+                entity_name,thumbnail_data
+            )
         return response
+
 
 @frappe.whitelist(allow_guest=True)
 def create_video_thumbnail(entity_name):
@@ -78,19 +90,22 @@ def create_video_thumbnail(entity_name):
     flag = False
     for z_entity_name in entity_ancestors:
         result = frappe.db.exists(
-                {
-                    "doctype": "DocShare",
-                    "share_doctype": "Drive Entity",
-                    "share_name": z_entity_name,
-                    "everyone": 1,
-                }
-            )
+            {
+                "doctype": "DocShare",
+                "share_doctype": "Drive Entity",
+                "share_name": z_entity_name,
+                "everyone": 1,
+            }
+        )
         if result:
             flag = True
             break
     if not flag:
         if not frappe.has_permission(
-            doctype="Drive Entity", doc=entity_name, ptype="read", user=frappe.session.user
+            doctype="Drive Entity",
+            doc=entity_name,
+            ptype="read",
+            user=frappe.session.user,
         ):
             raise frappe.PermissionError("You do not have permission to view this file")
     with DistributedLock(drive_entity.path, exclusive=False):
@@ -104,14 +119,16 @@ def create_video_thumbnail(entity_name):
             response.headers.set("Content-Disposition", "inline", filename=entity_name)
         else:
             user_thumbnails_directory = get_user_thumbnails_directory()
-            thumbnail_getpath= Path(user_thumbnails_directory,entity_name)
+            thumbnail_getpath = Path(user_thumbnails_directory, entity_name)
             with open(str(thumbnail_getpath) + ".thumbnail", "rb") as file:
                 thumbnail_data = BytesIO(file.read())
             response = Response(
-                wrap_file(frappe.request.environ,thumbnail_data),
+                wrap_file(frappe.request.environ, thumbnail_data),
                 direct_passthrough=True,
             )
             response.headers.set("Content-Type", "image/jpeg")
-            response.headers.set("Content-Disposition", "inline",filename=entity_name)
-            frappe.cache().set_value(entity_name,)
+            response.headers.set("Content-Disposition", "inline", filename=entity_name)
+            frappe.cache().set_value(
+                entity_name,thumbnail_data
+            )
         return response

--- a/drive/utils/files.py
+++ b/drive/utils/files.py
@@ -2,7 +2,9 @@ import frappe
 import os
 from pathlib import Path
 import hashlib
-
+from PIL import Image, ImageOps
+from drive.locks.distributed_lock import DistributedLock
+import cv2
 
 def create_user_directory():
     """
@@ -90,3 +92,59 @@ def get_new_title(entity, parent_name):
         if new_title not in sibling_entity_titles:
             return new_title
         i += 1
+
+def create_user_thumbnails_directory():
+    user_directory_name = _get_user_directory_name()
+    user_directory_thumnails_path = Path(
+        frappe.get_site_path("private/files"),user_directory_name,"thumbnails"
+    )
+    user_directory_thumnails_path.mkdir(exist_ok=False)
+    return user_directory_thumnails_path
+
+
+def get_user_thumbnails_directory(user=None):
+    user_directory_name = _get_user_directory_name(user)
+    user_directory_thumnails_path = Path(
+        frappe.get_site_path("private/files"),user_directory_name,"thumbnails"
+    )
+    if not os.path.exists(user_directory_thumnails_path):
+       raise FileNotFoundError("User thumbnails directory does not exist")
+    return user_directory_thumnails_path
+
+
+def create_thumbnail(entity_name,path,mime_type):
+    user_thumbnails_directory = None
+    try:
+        user_thumbnails_directory = get_user_thumbnails_directory()
+    except FileNotFoundError:
+        user_thumbnails_directory = create_user_thumbnails_directory()
+
+    thumbnail_savepath= Path(user_thumbnails_directory,entity_name)
+    with DistributedLock(path, exclusive=False):
+        if(mime_type.startswith('image')):
+            try:
+                image_path = path
+                with Image.open(image_path).convert("RGB") as image:
+                    image = ImageOps.exif_transpose(image)
+                    image.thumbnail((250, 250))
+                    image.save(str(thumbnail_savepath) + ".thumbnail", format="JPEG")
+            except  Exception as e:
+                print("Failed to create thumbnail")
+
+        if(mime_type.startswith('video')):
+            try:
+                video_path = str(path)
+                cap = cv2.VideoCapture(video_path)
+                frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+                target_frame = int(frame_count / 2)
+                cap.set(cv2.CAP_PROP_POS_FRAMES, target_frame)
+                ret, frame = cap.read()
+                cap.release()
+                _, thumbnail_encoded = cv2.imencode(
+                    ".jpg", frame, [int(cv2.IMWRITE_JPEG_QUALITY), 30]
+                )
+                with open(str(thumbnail_savepath) + ".thumbnail", "wb") as f:
+                    f.write(thumbnail_encoded)
+            except  Exception as e:
+                print(e)
+            


### PR DESCRIPTION
thumbnails filesystem deletion taken care of, max try added and other edge cases handled.
@netchampfaris 
It was brough to my notice that doing on the fly thumbnail creation was not the best approach.
In my defense, the same was implemented to not consume thumbnail space and make billing more simpler in case of FC.
It was not CPU internsive either.

I still believe on the fly approach would be better for dynamic resizing and other client specifc workloads,
but for the current stance, file system it is :)
