### PR TITLE
chore: loosely pin pillow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    "Pillow~=10.0.0",
+    "Pillow>=10.0.0,<11.0.0",
     "opencv-python==4.8.0.76",
     "python-magic==0.4.27",
 ]


### PR DESCRIPTION
https://discuss.frappe.io/t/frappe-15-15-0-requires-pillow-10-2-0/117567


Limited usage: https://github.com/frappe/drive/blob/9de2008901981e6c3f96d106320c8ff794f3827b/drive/utils/files.py#L140 

Not sure if this requires strictly pinning a vulnerable version. Framework already has this in dependency.  