### PR TITLE
build: don't rely on folder layout; adopt best practice

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,32 @@
 import { defineConfig } from "vite"
 import vue from "@vitejs/plugin-vue"
 import path from "path"
-import { webserver_port } from "../../../sites/common_site_config.json"
+import fs from "fs"
+
+function getCommonSiteConfig() {
+  let currentDir = path.resolve('.')
+  // traverse up till we find frappe-bench with sites directory
+  while (currentDir !== '/') {
+    if (
+      fs.existsSync(path.join(currentDir, 'sites')) &&
+      fs.existsSync(path.join(currentDir, 'apps'))
+    ) {
+      let configPath = path.join(currentDir, 'sites', 'common_site_config.json')
+      if (fs.existsSync(configPath)) {
+        return JSON.parse(fs.readFileSync(configPath))
+      }
+      return null
+    }
+    currentDir = path.resolve(currentDir, '..')
+  }
+  return null
+}
+
+const config = getCommonSiteConfig()
+const webserver_port = config ? config.webserver_port : 8000
+if (!config) {
+  console.log('No common_site_config.json found, using default port 8000')
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
###### Blocks: https://github.com/blaggacao/frappix/pull/11

```console
drive on  build/use-workspaces via  v18.20.4 via 🐍 v3.11.8 (pyenv) took 8s
❯ yarn build
yarn run v1.22.22
$ cd frontend && npm run build

> frontend@0.0.0 build
> vite build --base=/assets/drive/frontend/ && yarn copy-html-entry

✘ [ERROR] No matching export in "../../../.data/sites/common_site_config.json" for import "webserver_port"

    vite.config.js:4:9:
      4 │ import { webserver_port } from "../../../sites/common_site_config.json"
        ╵          ~~~~~~~~~~~~~~

failed to load config from /home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/drive/frontend/vite.config.js
error during build:
Error: Build failed with 1 error:
vite.config.js:4:9: ERROR: No matching export in "../../../.data/sites/common_site_config.json" for import "webserver_port"
    at failureErrorWithLog (/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/drive/node_modules/esbuild/lib/main.js:1649:15)
    at /home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/drive/node_modules/esbuild/lib/main.js:1058:25
    at runOnEndCallbacks (/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/drive/node_modules/esbuild/lib/main.js:1484:45)
    at buildResponseToResult (/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/drive/node_modules/esbuild/lib/main.js:1056:7)
    at /home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/drive/node_modules/esbuild/lib/main.js:1085:16
    at responseCallbacks.<computed> (/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/drive/node_modules/esbuild/lib/main.js:703:9)
    at handleIncomingPacket (/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/drive/node_modules/esbuild/lib/main.js:762:9)
    at Socket.readFromStdout (/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/drive/node_modules/esbuild/lib/main.js:679:7)
    at Socket.emit (node:events:519:28)
    at addChunk (node:internal/streams/readable:559:12)
npm error Lifecycle script `build` failed with error:
npm error Error: command failed
npm error   in workspace: frontend@0.0.0
npm error   at location: /home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/drive/frontend
```