### PR TITLE
fix: Enhance team management functionality

### DIFF
--- a/drive/drive/doctype/drive_team/drive_team.json
+++ b/drive/drive/doctype/drive_team/drive_team.json
@@ -1,47 +1,50 @@
 {
-  "actions": [],
-  "autoname": "hash",
-  "creation": "2025-01-23 12:12:04.979723",
-  "doctype": "DocType",
-  "engine": "InnoDB",
-  "field_order": ["title", "users"],
-  "fields": [
-    {
-      "fieldname": "title",
-      "fieldtype": "Small Text",
-      "label": "Title"
-    },
-    {
-      "fieldname": "users",
-      "fieldtype": "Table MultiSelect",
-      "label": "Users",
-      "options": "Drive Team Member"
-    }
-  ],
-  "index_web_pages_for_search": 1,
-  "links": [],
-  "modified": "2025-02-13 15:14:53.932622",
-  "modified_by": "Administrator",
-  "module": "Drive",
-  "name": "Drive Team",
-  "naming_rule": "Random",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    }
-  ],
-  "sort_field": "creation",
-  "sort_order": "DESC",
-  "states": [],
-  "title_field": "title"
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2025-01-23 12:12:04.979723",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "users"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Small Text",
+   "label": "Title"
+  },
+  {
+   "fieldname": "users",
+   "fieldtype": "Table",
+   "label": "Users",
+   "options": "Drive Team Member"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-02-17 15:11:02.124920",
+ "modified_by": "Administrator",
+ "module": "Drive",
+ "name": "Drive Team",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "title"
 }

--- a/drive/drive/doctype/drive_team_member/drive_team_member.json
+++ b/drive/drive/doctype/drive_team_member/drive_team_member.json
@@ -1,35 +1,40 @@
 {
-  "actions": [],
-  "allow_rename": 1,
-  "creation": "2025-01-23 13:08:15.285320",
-  "doctype": "DocType",
-  "editable_grid": 1,
-  "engine": "InnoDB",
-  "field_order": ["user", "is_admin"],
-  "fields": [
-    {
-      "fieldname": "user",
-      "fieldtype": "Link",
-      "label": "User",
-      "options": "User"
-    },
-    {
-      "default": "0",
-      "fieldname": "is_admin",
-      "fieldtype": "Check",
-      "label": "Is Admin"
-    }
-  ],
-  "index_web_pages_for_search": 1,
-  "istable": 1,
-  "links": [],
-  "modified": "2025-01-23 14:05:23.793517",
-  "modified_by": "Administrator",
-  "module": "Drive",
-  "name": "Drive Team Member",
-  "owner": "Administrator",
-  "permissions": [],
-  "sort_field": "creation",
-  "sort_order": "DESC",
-  "states": []
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-01-23 13:08:15.285320",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "user",
+  "is_admin"
+ ],
+ "fields": [
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "User",
+   "options": "User"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_admin",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Is Admin"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-02-17 15:11:21.183025",
+ "modified_by": "Administrator",
+ "module": "Drive",
+ "name": "Drive Team Member",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
 }


### PR DESCRIPTION
This PR fixes the issue preventing users from being added to teams and the ability to designate multiple administrators.

Changes made:
- Changed Drive Team users field from Table MultiSelect to Table for better user management
- Added in_list_view:1 to user and is_admin fields in Drive Team Member
- Enables adding multiple users to teams
- Allows designation of multiple team administrators
- Improves overall team management interface and usability

Testing:
- Verified ability to add multiple users to a team
- Confirmed multiple administrators can be designated
- Tested user interface improvements for team management