### PR TITLE
fix: Skip Website Users in check_invites function

### DIFF
--- a/drive/utils/users.py
+++ b/drive/utils/users.py
@@ -24,6 +24,8 @@ def get_all_users(team):
 
 
 def check_invites(doc, method=None):
+    if doc.get("user_type") == "Website User":
+        return
     invites = frappe.db.get_list(
         "Drive User Invitation",
         filters={"email": doc.email, "status": "Pending"},


### PR DESCRIPTION
This PR adds a condition to skip Website Users in the check_invites function, preventing unnecessary team creation for these users.

## Changes
- Added a condition to check if the user is of type "Website User" and return immediately if true
- This prevents the creation of Drive teams for Website Users who don't need Drive access

## Testing
- Verified that Website Users are properly skipped when the check_invites function is called