### PR TITLE
fix: Link with Scrubbed Title

### DIFF
--- a/frontend/src/utils/getLink.js
+++ b/frontend/src/utils/getLink.js
@@ -1,14 +1,16 @@
 import { toast } from "@/utils/toasts.js"
 import router from "../router.js"
+import { scrubTitle } from "@/utils/helpers.ts"
 
 export function getLinkStem(entity) {
+  const scrubbedName = scrubTitle(entity.name)
   return `${
     {
       true: "file",
       [new Boolean(entity.is_group)]: "folder",
       [new Boolean(entity.document)]: "document",
     }[true]
-  }/${entity.name}`
+  }/${scrubbedName}`
 }
 
 export function getLink(entity, copy = true) {

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -197,7 +197,14 @@ function getDataForKey(datum: Object, key: string) {
   const data = Object.assign({}, datum)
   return key.split(".").reduce((d, key) => (d ? d[key] : null), data) as string
 }
-
+export function scrubTitle(name) {
+  return name
+    .replace(/\.[^/.]+$/, "") // Remove file extension
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "") // Remove special characters except hyphens and spaces
+    .trim()
+    .replace(/[\s_-]+/g, "-"); // Replace spaces and underscores with hyphen
+}
 export {
   HSVToHex,
   HexToHSV,
@@ -216,4 +223,5 @@ export {
   isTargetEditable,
   kebabToCamelCase,
   stripExtension,
+  scrubTitle,
 }


### PR DESCRIPTION
This PR addresses an improvement to the link generation logic in getLink.js by introducing a scrubbed version of the entity title that omits file extensions and removes any special characters, spaces, or inconsistencies in casing.

Changes Made:
Introduced scrubTitle() utility function
Removes file extensions (e.g., .pdf, .docx) from entity names.
Converts text to lowercase.
Replaces special characters and whitespace with hyphens for URL-friendliness.

Updated getLinkStem() in getLink.js
Replaces entity.name with scrubTitle(entity.name) to ensure all URLs are cleaned before rendering.
Keeps entity type handling intact (file, folder, document).

Fixes: https://github.com/frappe/drive/issues/330