### PR TITLE
fix: replace deep imports from frappe-ui

### DIFF
--- a/frontend/src/components/CustomListRow.vue
+++ b/frontend/src/components/CustomListRow.vue
@@ -72,8 +72,7 @@
   </template>
 </template>
 <script setup>
-import { FeatherIcon, ListRowItem, ListRow } from "frappe-ui"
-import Tooltip from "frappe-ui/src/components/Tooltip/Tooltip.vue"
+import { FeatherIcon, ListRowItem, ListRow, Tooltip } from "frappe-ui"
 import { openEntity } from "@/utils/files"
 import { settings } from "@/resources/permissions"
 import { useRoute } from "vue-router"

--- a/frontend/src/components/InfoSidebar.vue
+++ b/frontend/src/components/InfoSidebar.vue
@@ -205,7 +205,7 @@
 <script setup>
 import { ref, computed, watch } from "vue"
 import { useStore } from "vuex"
-import { Avatar, call, createResource } from "frappe-ui"
+import { Avatar, call, createResource, Tooltip } from "frappe-ui"
 import { formatMimeType, formatDate } from "@/utils/format"
 import GeneralAccess from "@/components/GeneralAccess.vue"
 import { thumbnail_getIconUrl } from "@/utils/getIconUrl"
@@ -216,7 +216,6 @@ import Clock from "./EspressoIcons/Clock.vue"
 import ActivityTree from "./ActivityTree.vue"
 import TagInput from "@/components/TagInput.vue"
 import { generalAccess, userList } from "@/resources/permissions"
-import Tooltip from "frappe-ui/src/components/Tooltip/Tooltip.vue"
 
 const store = useStore()
 const tab = ref(0)

--- a/frontend/src/components/Settings/StorageSettings.vue
+++ b/frontend/src/components/Settings/StorageSettings.vue
@@ -118,8 +118,7 @@ import {
   formatPercent,
 } from "@/utils/format"
 import Cloud from "@/components/EspressoIcons/Cloud.vue"
-import FeatherIcon from "frappe-ui/src/components/FeatherIcon.vue"
-import { Tooltip } from "frappe-ui"
+import { Tooltip, FeatherIcon } from "frappe-ui"
 import { getIconUrl } from "@/utils/getIconUrl"
 import { openEntity, MIME_LIST_MAP } from "@/utils/files"
 import { createResource } from "frappe-ui"

--- a/frontend/src/components/Toast.vue
+++ b/frontend/src/components/Toast.vue
@@ -51,8 +51,7 @@
   </div>
 </template>
 <script>
-import { FeatherIcon, Button } from "frappe-ui"
-import Avatar from "frappe-ui/src/components/Avatar.vue"
+import { FeatherIcon, Button, Avatar } from "frappe-ui"
 
 export default {
   name: "Toast",

--- a/frontend/src/components/UploadTracker.vue
+++ b/frontend/src/components/UploadTracker.vue
@@ -186,9 +186,8 @@
 </template>
 <script>
 import { mapGetters } from "vuex"
-import { FeatherIcon } from "frappe-ui"
+import { FeatherIcon, Dialog } from "frappe-ui"
 import ProgressRing from "@/components/ProgressRing.vue"
-import Dialog from "frappe-ui/src/components/Dialog.vue"
 import File from "./EspressoIcons/File.vue"
 
 export default {

--- a/frontend/src/pages/Document.vue
+++ b/frontend/src/pages/Document.vue
@@ -39,12 +39,11 @@ import {
 } from "vue"
 import { useRoute } from "vue-router"
 import { useStore } from "vuex"
-import { createResource } from "frappe-ui"
+import { createResource, LoadingIndicator } from "frappe-ui"
 import { watchDebounced } from "@vueuse/core"
 import { setBreadCrumbs, prettyData } from "@/utils/files"
 import { allUsers } from "@/resources/permissions"
 import router from "@/router"
-import LoadingIndicator from "frappe-ui/src/components/LoadingIndicator.vue"
 
 const TextEditor = defineAsyncComponent(() =>
   import("@/components/DocEditor/TextEditor.vue")


### PR DESCRIPTION
Replacing deep imports from frappe-ui with imports from the entry file.
import component from "frappe-ui/src/components/component.vue" → import { component } from "frappe-ui"

This will break whenever frappe-ui is upgraded with this change: https://github.com/frappe/frappe-ui/pull/308
In general, its better to avoid deep imports to avoid breakage from changes in library's folder structure.