### PR TITLE
fix: Update custom list row components to use new props

### DIFF
--- a/frontend/src/components/CustomListRow.vue
+++ b/frontend/src/components/CustomListRow.vue
@@ -18,7 +18,13 @@
       @drop="$emit('dropped', row, draggedItem)"
     >
       <template #default="{ idx, column, item }">
-        <CustomListRowItem :column :row :item :idx />
+        <CustomListRowItem
+          :column="column"
+          :row="row"
+          :item="item"
+          :idx="idx"
+          :contextMenu="contextMenu"
+        />
       </template>
     </ListRow>
   </template>

--- a/frontend/src/components/CustomListRowItem.vue
+++ b/frontend/src/components/CustomListRowItem.vue
@@ -65,6 +65,7 @@ const props = defineProps({
   column: Object,
   row: Object,
   item: String,
+  contextMenu: Function,
 })
 
 let src, imgLoaded, thumbnailLink, backupLink, is_image


### PR DESCRIPTION
The parent component is not passing the [contextMenu] prop when rendering folder rows.

modified:   frontend/src/components/CustomListRow.vue
modified:   frontend/src/components/CustomListRowItem.vue

fix #379