### PR TITLE
Add missing translations for user-facing labels in UI

### DIFF
--- a/frontend/src/components/BottomBar.vue
+++ b/frontend/src/components/BottomBar.vue
@@ -70,7 +70,7 @@ export default {
         //   highlight: () => {},
         // },
         {
-          label: "Home",
+          label: __("Home"),
           route: "/t/" + this.team,
           icon: Home,
           highlight: () => {
@@ -78,7 +78,7 @@ export default {
           },
         },
         {
-          label: "Recents",
+          label: __("Recents"),
           route: "/t/" + this.team + "/recents",
           icon: Recent,
           highlight: () => {
@@ -86,7 +86,7 @@ export default {
           },
         },
         {
-          label: "Favourites",
+          label: __("Favourites"),
           route: "/t/" + this.team + "/favourites",
           icon: Star,
           highlight: () => {
@@ -94,7 +94,7 @@ export default {
           },
         },
         {
-          label: "Team",
+          label: __("Team"),
           route: "/t/" + this.team + "/team",
           icon: Team,
           highlight: () => {
@@ -102,7 +102,7 @@ export default {
           },
         },
         {
-          label: "Shared",
+          label: __("Shared"),
           route: "/shared",
           icon: Users,
           highlight: () => {
@@ -110,7 +110,7 @@ export default {
           },
         },
         {
-          label: "Trash",
+          label: __("Trash"),
           route: "/t/" + this.team + "/trash",
           icon: Trash,
           highlight: () => {

--- a/frontend/src/components/DocEditor/commands.js
+++ b/frontend/src/components/DocEditor/commands.js
@@ -11,37 +11,37 @@ import ToggleHeaderCell from "./icons/ToggleHeaderCell.vue"
 
 export default {
   Bold: {
-    label: "Bold",
+    label: __("Bold"),
     icon: Bold,
     action: (editor) => editor.chain().focus().toggleBold().run(),
     isActive: (editor) => editor.isActive("bold"),
   },
   Italic: {
-    label: "Italic",
+    label: __("Italic"),
     icon: Italic,
     action: (editor) => editor.chain().focus().toggleItalic().run(),
     isActive: (editor) => editor.isActive("italic"),
   },
   Underline: {
-    label: "Underline",
+    label: __("Underline"),
     icon: Underline,
     action: (editor) => editor.chain().focus().toggleUnderline().run(),
     isActive: (editor) => editor.isActive("underline"),
   },
   Strikethrough: {
-    label: "Strikethrough",
+    label: __("Strikethrough"),
     icon: Strikethrough,
     action: (editor) => editor.chain().focus().toggleStrike().run(),
     isActive: (editor) => editor.isActive("strike"),
   },
   Code: {
-    label: "Code",
+    label: __("Code"),
     icon: Code,
     action: (editor) => editor.chain().focus().toggleCode().run(),
     isActive: (editor) => editor.isActive("code"),
   },
   Link: {
-    label: "New Link",
+    label: __("New Link"),
     icon: NewLink,
     isActive: (editor) => editor.isActive("link"),
     component: defineAsyncComponent(() =>
@@ -52,7 +52,7 @@ export default {
     type: "separator",
   },
   NewAnnotation: {
-    label: "New Annotation",
+    label: __("New Annotation"),
     icon: NewCommentIcon,
     isActive: (editor) => editor.isActive("comment"),
     component: defineAsyncComponent(() =>
@@ -60,7 +60,7 @@ export default {
     ),
   },
   Comment: {
-    label: "New Comment",
+    label: __("New Comment"),
     icon: NewLink,
     isActive: (editor) => editor.isActive("comment"),
     component: defineAsyncComponent(() =>
@@ -68,19 +68,19 @@ export default {
     ),
   },
   MergeCells: {
-    label: "Merge Cells",
+    label: __("Merge Cells"),
     icon: TableCellsMerge,
     isActive: () => false,
     action: (editor) => editor.chain().focus().mergeCells().run(),
   },
   SplitCells: {
-    label: "Split Cells",
+    label: __("Split Cells"),
     icon: TableCellsSplit,
     isActive: () => false,
     action: (editor) => editor.chain().focus().splitCell().run(),
   },
   ToggleHeaderCell: {
-    label: "Toggle Header",
+    label: __("Toggle Header"),
     icon: ToggleHeaderCell,
     isActive: () => false,
     action: (editor) => editor.chain().focus().toggleHeaderCell().run(),

--- a/frontend/src/components/MoveDialog.vue
+++ b/frontend/src/components/MoveDialog.vue
@@ -228,15 +228,15 @@ const dropDownItems = computed(() => {
 
 const tabs = [
   {
-    label: "Home",
+    label: __("Home"),
     icon: h(Home, { class: "w-4 h-4" }),
   },
   {
-    label: "Team",
+    label: __("Team"),
     icon: h(Team, { class: "w-4 h-4" }),
   },
   // {
-  //   label: "Favourites",
+  //   label: __("Favourites"),
   //   icon: h(Star, { class: "w-4 h-4" }),
   // },
 ]

--- a/frontend/src/components/Tag.vue
+++ b/frontend/src/components/Tag.vue
@@ -68,7 +68,7 @@ export default {
       colors: ["gray", "blue", "green", "orange", "red"],
       tagActions: [
         {
-          label: "Delete",
+          label: __("Delete"),
           icon: "trash-2",
           handler: () => {
             this.$resources.deleteTag.submit()

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -46,7 +46,9 @@ const store = createStore({
       team: getJson("currentFolderTeam", {}),
       entities: getJson("currentEntitites", []),
     },
-    breadcrumbs: getJson("breadcrumbs", [{ label: __("Home"), route: "/" }]),
+    // Should renamed or left as this since its breadcrubs?
+    //breadcrumbs: getJson("breadcrumbs", [{ label: __("Home"), route: "/" }]),
+    breadcrumbs: getJson("breadcrumbs", [{ label: "Home", route: "/" }]),
     // Writer ones
     hasWriteAccess: false,
     allComments: "",

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -30,7 +30,7 @@ const store = createStore({
     uploads: [],
     connectedUsers: [],
     sortOrder: getJson("sortOrder", {
-      label: "Modified",
+      label: __("Modified"),
       field: "modified",
       ascending: false,
     }),
@@ -46,7 +46,7 @@ const store = createStore({
       team: getJson("currentFolderTeam", {}),
       entities: getJson("currentEntitites", []),
     },
-    breadcrumbs: getJson("breadcrumbs", [{ label: "Home", route: "/" }]),
+    breadcrumbs: getJson("breadcrumbs", [{ label: __("Home"), route: "/" }]),
     // Writer ones
     hasWriteAccess: false,
     allComments: "",


### PR DESCRIPTION
changes are made in Github web interface not **tested yet**

#### Changes include:
- Breadcrumbs, navigation, and sidebar items now use `__()` for their labels.
- Command bar and editor toolbar actions (e.g., Bold, Italic) are now translated.
- Dialogs, tabs, and tag actions use translation wrappers for their labels.
- Notifications and list/table columns have translated headers.
- Sort order and state defaults in the store now use translated strings.

#### Affected files:
- `frontend/src/store.js`
- `frontend/src/pages/Team.vue`
- `frontend/src/components/DocEditor/commands.js`
- `frontend/src/components/MoveDialog.vue`
- `frontend/src/components/BottomBar.vue` (Not srue if its need translation but edited)
- `frontend/src/components/Tag.vue`
- `frontend/src/pages/Notifications.vue`