### PR TITLE
fix: Add default value for personal_prefix in Settings

### DIFF
--- a/drive/drive/doctype/drive_disk_settings/drive_disk_settings.json
+++ b/drive/drive/doctype/drive_disk_settings/drive_disk_settings.json
@@ -100,6 +100,7 @@
       "label": "Team Prefix"
     },
     {
+      "default": "personal",
       "fieldname": "personal_prefix",
       "fieldtype": "Data",
       "label": "Personal Prefix"


### PR DESCRIPTION
closes https://github.com/frappe/drive/issues/477