### PR TITLE
fix: handle None duration in create_version to prevent TypeError

### DIFF
--- a/drive/api/docs.py
+++ b/drive/api/docs.py
@@ -95,7 +95,7 @@ def create_version(doc, snapshot, duration=None, manual=0, title=""):
             prev_time = datetime.strptime(title, "%Y-%m-%d %H:%M")
             now_time = frappe.utils.now_datetime()
             diff = now_time - prev_time
-            if diff < timedelta(minutes=duration):
+            if duration is not None and diff < timedelta(minutes=duration):
                 return False
             title = datetime.strftime(now_time, "%Y-%m-%d %H:%M")
         else:


### PR DESCRIPTION
<img width="2034" height="940" alt="CleanShot 2025-12-10 at 16 36 36@2x" src="https://github.com/user-attachments/assets/f9ba9e27-25ff-4b67-8523-c603708af583" />


<img width="2464" height="742" alt="CleanShot 2025-12-10 at 16 36 44@2x" src="https://github.com/user-attachments/assets/735a2c76-7e93-4bea-9c3e-568837e99d97" />
