### PR TITLE
feat: Add i18n translation wrappers to Vue components

### DIFF
--- a/frontend/src/components/BottomBar.vue
+++ b/frontend/src/components/BottomBar.vue
@@ -45,7 +45,7 @@ export default {
       const first = this.$store.state.breadcrumbs[0] || {}
       return [
         {
-          label: "Home",
+          label: this.__("Home"),
           route: "/",
           icon: LucideHome,
           highlight: () => {
@@ -53,7 +53,7 @@ export default {
           },
         },
         {
-          label: "Team",
+          label: this.__("Team"),
           route: "/teams",
           icon: LucideBuilding2,
           highlight: () => {
@@ -61,7 +61,7 @@ export default {
           },
         },
         {
-          label: "Recents",
+          label: this.__("Recents"),
           route: "/recents",
           icon: LucideClock,
           highlight: () => {
@@ -70,7 +70,7 @@ export default {
         },
 
         {
-          label: "Shared",
+          label: this.__("Shared"),
           route: "/shared",
           icon: LucideUsers,
           highlight: () => {
@@ -78,7 +78,7 @@ export default {
           },
         },
         {
-          label: "Favourites",
+          label: this.__("Favourites"),
           route: "/favourites",
           icon: LucideStar,
           highlight: () => {

--- a/frontend/src/components/ConfirmDialog.vue
+++ b/frontend/src/components/ConfirmDialog.vue
@@ -10,7 +10,7 @@
           <template v-if="props.entities.length">
             {{
               props.entities.length > 1
-                ? "These items "
+                ? __("These items ")
                 : `"${props.entities[0].title}" `
             }}
           </template>
@@ -53,15 +53,13 @@ const open = ref(true)
 
 const dialogData = computed(() => {
   const itemString =
-    props.entities.length === 1 ? "an item" : `${props.entities.length} items`
+    props.entities.length === 1 ? __("an item") : __("{0} items").replace("{0}", props.entities.length)
   const MAP = {
     restore: {
-      title: `Restore ${itemString}`,
-      message: `will be restored to ${
-        props.entities.length === 1
-          ? "its original location"
-          : "their original locations"
-      }.`,
+      title: __("Restore {0}").replace("{0}", itemString),
+      message: props.entities.length === 1
+        ? __("will be restored to its original location.")
+        : __("will be restored to their original locations."),
       url: "drive.api.files.remove_or_restore",
       onSuccess: () => {
         getTrash.setData((d) =>
@@ -70,18 +68,18 @@ const dialogData = computed(() => {
       },
       button: {
         variant: "solid",
-        label: "Restore",
+        label: __("Restore"),
         iconLeft: LucideRotateCcw,
       },
-      toastMessage: `Restored ${itemString}.`,
+      toastMessage: __("Restored {0}.").replace("{0}", itemString),
     },
     remove: {
-      title: `Move ${itemString} to Trash`,
+      title: __("Move {0} to Trash").replace("{0}", itemString),
       message:
-        "will be moved to Trash.<br/><br/> Items in trash are deleted forever after 30 days.",
+        __("will be moved to Trash.") + "<br/><br/>" + __("Items in trash are deleted forever after 30 days."),
       url: "drive.api.files.remove_or_restore",
       button: {
-        label: "Move to Trash",
+        label: __("Move to Trash"),
         theme: "red",
         variant: "subtle",
       },
@@ -97,38 +95,38 @@ const dialogData = computed(() => {
           ])
         )
       },
-      toastMessage: `Moved ${itemString} to Trash.`,
+      toastMessage: __("Moved {0} to Trash.").replace("{0}", itemString),
     },
     d: {
-      title: `Delete ${itemString}`,
+      title: __("Delete {0}").replace("{0}", itemString),
       url: "drive.api.files.delete_entities",
       message:
-        " will be deleted - you can no longer access it.<br/><br/> <span class=font-semibold>This is an irreversible action.<span>",
+        __("will be deleted - you can no longer access it.") + "<br/><br/> <span class=font-semibold>" + __("This is an irreversible action.") + "<span>",
       button: {
-        label: "Delete — forever.",
+        label: __("Delete — forever."),
         theme: "red",
         iconLeft: LucideTrash,
         variant: "solid",
       },
-      toastMessage: `Deleted ${itemString}.`,
+      toastMessage: __("Deleted {0}.").replace("{0}", itemString),
     },
     "cta-recents": {
-      title: "Are you sure?",
-      message: "All your recently viewed files will be cleared.",
-      button: { label: "Clear" },
+      title: __("Are you sure?"),
+      message: __("All your recently viewed files will be cleared."),
+      button: { label: __("Clear") },
       resource: clearRecent,
     },
     "cta-favourites": {
-      title: "Are you sure?",
-      message: "All your favourite items will be cleared.",
-      button: { label: "Clear" },
+      title: __("Are you sure?"),
+      message: __("All your favourite items will be cleared."),
+      button: { label: __("Clear") },
       resource: toggleFav,
     },
     "cta-trash": {
-      title: "Clear your Trash",
+      title: __("Clear your Trash"),
       message:
-        "All items in your Trash will be deleted forever. <br/><br/> <span class=font-semibold>This is an irreversible process.</span>",
-      button: { label: "Delete", variant: "solid", iconLeft: LucideTrash },
+        __("All items in your Trash will be deleted forever.") + " <br/><br/> <span class=font-semibold>" + __("This is an irreversible process.") + "</span>",
+      button: { label: __("Delete"), variant: "solid", iconLeft: LucideTrash },
       resource: clearTrash,
     },
   }

--- a/frontend/src/components/DocEditor/TextEditor.vue
+++ b/frontend/src/components/DocEditor/TextEditor.vue
@@ -14,23 +14,23 @@
           <span class="font-medium">{{ current.title }}</span>
         </div>
         <div v-else>
-          This is a automatic snapshot of this document from
+          {{ __("This is a automatic snapshot of this document from") }}
           {{ formatDate(current.title) }}.
         </div>
         <div class="text-xs text-ink-gray-5">
-          Editing is disabled until you exit this preview.
+          {{ __("Editing is disabled until you exit this preview.") }}
         </div>
       </div>
       <div class="flex gap-2">
         <Button
           variant="ghost"
-          label="Exit"
+          :label="__('Exit')"
           class="hover:!bg-surface-gray-2 hover:underline"
           @click="emitter.emit('clear-snapshot')"
         />
         <Button
           variant="solid"
-          label="Restore"
+          :label="__('Restore')"
           @click="emitter.emit('restore-snapshot', current)"
         />
       </div>
@@ -77,7 +77,7 @@
             }
           "
           :mentions="{ mentions: users, selectable: false }"
-          placeholder="Start writing here..."
+          :placeholder="__('Start writing here...')"
           :bubble-menu="settings.minimal && menuButtons"
           :extensions="editorExtensions"
           :autofocus="true"
@@ -247,7 +247,7 @@ watch(
   () => props.currentVersion,
   (val) => {
     if (!val) return
-    toast("Changing version")
+    toast(__("Changing version"))
     const { view } = editor.value
     view.dispatch(
       view.state.tr.setMeta(ySyncPluginKey, {
@@ -580,7 +580,7 @@ onKeyDown("s", (e) => {
   e.preventDefault()
   emit("saveDocument")
   toast({
-    title: "Saving document",
+    title: __("Saving document"),
   })
 })
 

--- a/frontend/src/components/DocEditor/components/NewVersionDialog.vue
+++ b/frontend/src/components/DocEditor/components/NewVersionDialog.vue
@@ -2,7 +2,7 @@
   <FormControl
     v-model="versionName"
     v-focus
-    label="Name:"
+    :label="__('Name:')"
   >
     <template #prefix>
       <LucideVersion class="size-4" />
@@ -10,7 +10,7 @@
   </FormControl>
   <Button
     type="submit"
-    label="Create"
+    :label="__('Create')"
     variant="solid"
     class="w-full mt-4"
     :disabled="!versionName"

--- a/frontend/src/components/DocEditor/components/VersionsSidebar.vue
+++ b/frontend/src/components/DocEditor/components/VersionsSidebar.vue
@@ -11,7 +11,7 @@
         v-model="tab"
         class="w-full"
         as="div"
-        :tabs="[{ label: 'Automatic' }, { label: 'Manual' }]"
+        :tabs="[{ label: __('Automatic') }, { label: __('Manual') }]"
       />
       <Button
         :icon="LucideX"
@@ -29,7 +29,7 @@
         @click="
           clearSnapshot(),
           createDialog({
-            title: 'Create Version',
+            title: __('Create Version'),
             size: 'sm',
             component: h(NewVersionDialog),
             props: { editor },
@@ -43,7 +43,7 @@
         "
         class="text-ink-gray-5 text-sm text-center mt-1"
       >
-        None yet.
+        {{ __("None yet.") }}
       </div>
       <div
         v-for="[title, group] in Object.entries(groupedVersions)"
@@ -130,13 +130,13 @@ watch(tab, () => clearSnapshot(false))
 
 emitter.on("restore-snapshot", (details) => {
   createDialog({
-    title: "Are you sure?",
+    title: __("Are you sure?"),
     message: details.manual
-      ? `You are restoring to a previous version: ${details.title}.`
-      : `You are restoring the document to how it was at ${details.title}.`,
+      ? __("You are restoring to a previous version:") + ` ${details.title}.`
+      : __("You are restoring the document to how it was at") + ` ${details.title}.`,
     actions: [
       {
-        label: "Confirm",
+        label: __("Confirm"),
         variant: "solid",
         onClick: () => {
           const view = props.editor.view

--- a/frontend/src/components/DocEditor/components/WriterSettings.vue
+++ b/frontend/src/components/DocEditor/components/WriterSettings.vue
@@ -2,7 +2,7 @@
   <Dialog
     v-model="open"
     :options="{
-      title: 'Settings',
+      title: __('Settings'),
     }"
     @close="model = false"
   >
@@ -16,53 +16,49 @@
             <Form>
               <template #default="{ dirty, setDirty, error }">
                 <h3 class="text-sm font-medium text-ink-gray-7 mb-3">
-                  Configuration
+                  {{ __("Configuration") }}
                 </h3>
                 <div class="flex flex-col gap-4 pb-5 pr-5">
                   <FormControl
                     v-model="settings.versioning"
                     type="number"
                     min="1"
-                    label="Versioning Frequency"
-                    placeholder="Default"
+                    :label="__('Versioning Frequency')"
+                    :placeholder="__('Default')"
                     :options="[]"
                     :validate="
                       (k) =>
                         k >= 1
                           ? true
-                          : 'Please give a positive whole number for versioning frequency.'
+                          : __('Please give a positive whole number for versioning frequency.')
                     "
-                    :description="`How often to take automated versions for ${
-                      tabIndex === 1 ? 'this document' : 'new documents'
-                    } (minutes).`"
+                    :description="tabIndex === 1 ? __('How often to take automated versions for this document (minutes).') : __('How often to take automated versions for new documents (minutes).')"
                   />
                 </div>
                 <h3 class="text-sm font-medium text-ink-gray-7 mb-3">
-                  Styles
+                  {{ __("Styles") }}
                 </h3>
                 <div class="flex flex-col gap-4 pb-5 pr-5">
                   <FormControl
                     v-model="settings.font_family"
                     type="select"
-                    label="Font Family"
+                    :label="__('Font Family')"
                     :options="fontOptions"
-                    :description="`Choose the default font family for ${
-                      tabIndex === 1 ? 'this document' : 'new documents'
-                    }.`"
+                    :description="tabIndex === 1 ? __('Choose the default font family for this document.') : __('Choose the default font family for new documents.')"
                   />
                   <FormControl
                     v-model="settings.font_size"
                     type="select"
-                    label="Font Size"
+                    :label="__('Font Size')"
                     :options="fontSizeOptions"
-                    :description="'Set the font size  of the editor (px).'"
+                    :description="__('Set the font size of the editor (px).')"
                   />
                   <FormControl
                     v-model="settings.line_height"
                     type="select"
-                    label="Line Height"
+                    :label="__('Line Height')"
                     :options="lineHeightOptions"
-                    description="Set the line height of the editor."
+                    :description="__('Set the line height of the editor.')"
                   />
                   <!-- <FormControl
                     label="Custom Classes"
@@ -79,7 +75,7 @@
                       {{ error }}
                     </div>
                     <Button
-                      label="Update"
+                      :label="__('Update')"
                       variant="solid"
                       class="w-full mt-3"
                       :disabled="!dirty || error"
@@ -115,15 +111,15 @@ const props = defineProps({
   editable: Boolean,
 })
 const tabs = dynamicList([
-  { label: "Everywhere", icon: LucideGlobe2 },
-  { label: "This document", icon: LucideFileText },
+  { label: __("Everywhere"), icon: LucideGlobe2 },
+  { label: __("This document"), icon: LucideFileText },
 ])
 const tabIndex = ref(props.editable ? 1 : 0)
 
 const fontOptions = computed(() =>
   dynamicList([
     {
-      label: "Automatic",
+      label: __("Automatic"),
       value: "global",
       cond: tabIndex.value === 1,
     },
@@ -133,7 +129,7 @@ const fontOptions = computed(() =>
 const fontSizeOptions = computed(() =>
   dynamicList([
     {
-      label: "Automatic",
+      label: __("Automatic"),
       value: "global",
       cond: tabIndex.value === 1,
     },
@@ -149,7 +145,7 @@ const fontSizeOptions = computed(() =>
 const lineHeightOptions = computed(() =>
   dynamicList([
     {
-      label: "Automatic",
+      label: __("Automatic"),
       value: "global",
       cond: tabIndex.value === 1,
     },

--- a/frontend/src/components/GenericPage.vue
+++ b/frontend/src/components/GenericPage.vue
@@ -149,7 +149,7 @@ const sortId = computed(
 )
 const sortOrder = ref(
   store.state.sortOrder[sortId.value] || {
-    label: "Modified",
+    label: __("Modified"),
     field: "modified",
     ascending: false,
   }
@@ -277,14 +277,14 @@ const actionItems = computed(() => {
   if (route.name === "Trash") {
     return [
       {
-        label: "Restore",
+        label: __("Restore"),
         icon: LucideRotateCcw,
         action: () => (dialog.value = "restore"),
         multi: true,
         important: true,
       },
       {
-        label: "Delete forever",
+        label: __("Delete forever"),
         icon: LucideTrash,
         action: () => (dialog.value = "d"),
         isEnabled: () => route.name === "Trash",
@@ -416,11 +416,11 @@ async function newLink() {
     const url = new URL(text)
     if (url.host)
       toast({
-        title: "Link detected",
+        title: __("Link detected"),
         text,
         buttons: [
           {
-            label: "Add",
+            label: __("Add"),
             onClick: () => {
               dialog.value = "l"
             },

--- a/frontend/src/components/MoveDialog.vue
+++ b/frontend/src/components/MoveDialog.vue
@@ -9,10 +9,10 @@
         <div class="flex w-full justify-between gap-x-15 mb-4">
           <div class="font-semibold text-2xl flex text-nowrap overflow-hidden">
             <template v-if="props.entities.length > 1">
-              Moving {{ props.entities.length }} items
+              {{ __("Moving {0} items").replace("{0}", props.entities.length) }}
             </template>
             <template v-else>
-              Moving "
+              {{ __("Moving") }} "
               <div class="truncate max-w-[80%]">
                 {{ props.entities[0].title }}
               </div>
@@ -120,7 +120,7 @@
                         <span
                           v-if="entities[0].parent_entity === node.value"
                           class="text-ink-gray-5"
-                          >(current)</span
+                          >({{ __("current") }})</span
                         ></span
                       >
                       <Button
@@ -133,7 +133,7 @@
                             let obj = {
                               parent: node.value,
                               value: null,
-                              label: 'New folder',
+                              label: __('New folder'),
                             }
                             node.children.push(obj)
                             if (isCollapsed) toggleCollapsed(e)
@@ -160,7 +160,7 @@
                   class="self-center text-sm text-ink-gray-6 flex flex-col gap-2"
                 >
                   <LucideFolderClosed class="size-5 self-center" />
-                  No folders found
+                  {{ __("No folders found") }}
                 </div>
               </div>
             </div>
@@ -168,7 +168,7 @@
         </Tabs>
         <div class="flex items-center justify-between pt-4">
           <div class="flex items-center my-auto justify-start">
-            <p class="text-sm pr-0.5">Moving to:</p>
+            <p class="text-sm pr-0.5">{{ __("Moving to:") }}</p>
             <Dropdown
               v-if="dropDownBreadcrumbs.length"
               class="h-7"
@@ -220,7 +220,7 @@
             <template #prefix>
               <LucideArrowLeftRight class="size-4" />
             </template>
-            Move
+            {{ __("Move") }}
           </Button>
         </div>
       </div>

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -62,12 +62,12 @@
           variant="outline"
           @click="$router.push({ name: 'Login' })"
         >
-          Sign In
+          {{ __("Sign In") }}
         </Button>
         <Button
           class="hidden md:block"
           variant="solid"
-          label="Try out Drive"
+          :label="__('Try out Drive')"
           @click="
             open('https://frappecloud.com/dashboard/signup?product=drive')
           "
@@ -91,7 +91,7 @@
         :button="{
           variant: 'solid',
           id: 'create-button',
-          label: 'Create',
+          label: __('Create'),
           iconLeft: h(LucidePlus, { class: 'size-4' }),
         }"
         :options="newEntityOptions"
@@ -100,7 +100,7 @@
       <Button
         v-else-if="$route.name === 'Documents' || $route.name === 'Slides'"
         id="create-button"
-        label="Create"
+        :label="__('Create')"
         variant="solid"
         :icon-left="h(LucidePlus, { class: 'size-4' })"
         @click="
@@ -316,41 +316,41 @@ const button = computed(() =>
 
 const newEntityOptions = computed(() => [
   {
-    group: "Create",
+    group: __("Create"),
     items: dynamicList([
       {
-        label: "Document",
+        label: __("Document"),
         icon: LucideFilePlus2,
         onClick: () => newExternal("Document"),
       },
       {
-        label: "Presentation",
+        label: __("Presentation"),
         icon: LucideGalleryVerticalEnd,
         onClick: () => (dialog.value = "p"),
         cond: isPrivate.value && apps.data?.find?.((k) => k.name === "slides"),
       },
       {
-        label: "Folder",
+        label: __("Folder"),
         icon: LucideFolderPlus,
         onClick: () => (dialog.value = "f"),
       },
       {
-        label: "Link",
+        label: __("Link"),
         icon: LucideLink,
         onClick: () => (dialog.value = "l"),
       },
     ]),
   },
   {
-    group: "Upload",
+    group: __("Upload"),
     items: [
       {
-        label: "Upload File",
+        label: __("Upload File"),
         icon: LucideFileUp,
         onClick: () => emitter.emit("uploadFile"),
       },
       {
-        label: "Upload Folder",
+        label: __("Upload Folder"),
         icon: LucideFolderUp,
         onClick: () => emitter.emit("uploadFolder"),
       },

--- a/frontend/src/components/NewFolderDialog.vue
+++ b/frontend/src/components/NewFolderDialog.vue
@@ -2,11 +2,11 @@
   <Dialog
     v-model="open"
     :options="{
-      title: 'Create a Folder',
+      title: __('Create a Folder'),
       size: 'xs',
       actions: [
         {
-          label: 'Create',
+          label: __('Create'),
           variant: 'solid',
           disabled: folderName.length === 0,
           loading: createFolder.loading,
@@ -20,7 +20,7 @@
       <FormControl
         v-model="folderName"
         v-focus
-        label="Name:"
+        :label="__('Name:')"
         @keyup.enter="submit"
         @keydown="createFolder.error = null"
       >
@@ -65,7 +65,7 @@ const createFolder = createResource({
   },
   validate(params) {
     if (!params?.title) {
-      return "Folder name is required"
+      return __("Folder name is required")
     }
   },
   onSuccess(data) {

--- a/frontend/src/components/NewLinkDialog.vue
+++ b/frontend/src/components/NewLinkDialog.vue
@@ -2,11 +2,11 @@
   <Dialog
     v-model="open"
     :options="{
-      title: 'New Link',
+      title: __('New Link'),
       size: 'xs',
       actions: [
         {
-          label: 'Create',
+          label: __('Create'),
           variant: 'solid',
           loading: createLink.loading,
           onClick: createLink.submit,
@@ -20,13 +20,13 @@
         <FormControl
           v-model="title"
           v-focus
-          label="Link name"
+          :label="__('Link name')"
           type="text"
           @keydown="createLink.error = null"
         />
         <FormControl
           v-model="link"
-          label="URL"
+          :label="__('URL')"
           type="url"
           @keydown.enter="createLink.submit"
           @keydown="createLink.error = null"
@@ -70,7 +70,7 @@ const createLink = createResource({
   }),
   validate(params) {
     if (!params?.title) {
-      return "Link name is required"
+      return __("Link name is required")
     }
   },
   onSuccess(data) {

--- a/frontend/src/components/RenameDialog.vue
+++ b/frontend/src/components/RenameDialog.vue
@@ -2,11 +2,11 @@
   <Dialog
     v-model="open"
     :options="{
-      title: 'Rename',
+      title: __('Rename'),
       size: 'xs',
       actions: [
         {
-          label: 'Confirm',
+          label: __('Confirm'),
           variant: 'solid',
           disabled: !newTitle || newTitle === entity.title,
           onClick: submit,

--- a/frontend/src/components/Settings/BackendSettings.vue
+++ b/frontend/src/components/Settings/BackendSettings.vue
@@ -4,7 +4,7 @@
       {{ __("Storage") }}
     </h1>
     <Button
-      label="Sync"
+      :label="__('Sync')"
       class="ml-auto mr-4"
       @click="confirmSync"
     />
@@ -20,74 +20,74 @@
     >
       <FormControl
         v-model="generalSettings.root_folder"
-        label="Root Folder Name"
+        :label="__('Root Folder Name')"
         placeholder="/"
-        description="Where to store Drive files, defaults to the root folder."
+        :description="__('Where to store Drive files, defaults to the root folder.')"
       />
       <FormControl
         v-model="generalSettings.team_prefix"
         type="select"
-        label="Team Prefix"
+        :label="__('Team Prefix')"
         :options="[
-          { label: 'Team ID', value: 'team_id' },
-          { label: 'Team Name', value: 'team_name' },
-          { label: 'None', value: 'none' },
+          { label: __('Team ID'), value: 'team_id' },
+          { label: __('Team Name'), value: 'team_name' },
+          { label: __('None'), value: 'none' },
         ]"
-        description="The folder name for each team, defaults to the team name."
+        :description="__('The folder name for each team, defaults to the team name.')"
       />
 
       <FormControl
         v-model="generalSettings.backend_type"
         type="select"
-        label="Backend Type"
+        :label="__('Backend Type')"
         :options="[
-          { label: 'Disk', value: 'disk' },
-          { label: 'S3', value: 's3' },
+          { label: __('Disk'), value: 'disk' },
+          { label: __('S3'), value: 's3' },
         ]"
-        description="Whether to store on disk or on an S3 bucket."
+        :description="__('Whether to store on disk or on an S3 bucket.')"
       />
       <div
         v-if="generalSettings.backend_type === 's3'"
         class="flex flex-col gap-4 mt-2"
       >
         <h3 class="font-semibold text-md">
-          S3 Settings
+          {{ __("S3 Settings") }}
         </h3>
         <FormControl
           v-model="s3Settings.aws_key"
-          label="AWS Key"
+          :label="__('AWS Key')"
           required
-          placeholder="Enter AWS Key"
+          :placeholder="__('Enter AWS Key')"
         />
         <FormControl
           v-model="s3Settings.aws_secret"
-          label="AWS Secret"
+          :label="__('AWS Secret')"
           required
-          placeholder="Enter AWS Secret"
-          description="This isn't shown after you submit it."
+          :placeholder="__('Enter AWS Secret')"
+          :description="__('This is not shown after you submit it.')"
           type="password"
         />
         <FormControl
           v-model="s3Settings.bucket"
           required
-          label="S3 Bucket"
+          :label="__('S3 Bucket')"
           placeholder="bucket.example"
         />
         <FormControl
           v-model="s3Settings.endpoint_url"
-          label="Endpoint URL"
-          placeholder="Enter Endpoint URL"
-          description="Optional, only if using a custom endpoint."
+          :label="__('Endpoint URL')"
+          :placeholder="__('Enter Endpoint URL')"
+          :description="__('Optional, only if using a custom endpoint.')"
         />
         <FormControl
           v-model="s3Settings.signature_version"
-          label="Signature Version"
+          :label="__('Signature Version')"
           placeholder="s3v4"
-          description="Optional. Some providers only support 's3'."
+          :description="__('Optional. Some providers only support s3.')"
         />
       </div>
       <Button
-        label="Update"
+        :label="__('Update')"
         variant="solid"
         :disabled="!edited"
         :loading="updateSettings.isLoading"
@@ -140,7 +140,7 @@ watch(
 
 function confirmSync() {
   createDialog({
-    title: "Sync files from S3",
+    title: __("Sync files from S3"),
     component: markRaw(SyncBreakdown),
   })
 }
@@ -163,7 +163,7 @@ const updateSettings = createResource({
   onSuccess() {
     edited.value = false
     toast({
-      title: "S3 settings updated successfully",
+      title: __("S3 settings updated successfully"),
     })
   },
 })

--- a/frontend/src/components/Settings/EditTagDialog.vue
+++ b/frontend/src/components/Settings/EditTagDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <Dialog
     v-model="open"
-    :options="{ title: 'Edit Tag', size: 'sm' }"
+    :options="{ title: __('Edit Tag'), size: 'sm' }"
   >
     <template #body-content>
       <div class="flex flex-col items-stretch justify- gap-y-4">
@@ -16,7 +16,7 @@
           type="text"
           class="w-full"
           :placeholder="props.tag.title"
-          label="Title"
+          :label="__('Title')"
           @keyup.enter="submitTag"
         />
       </div>
@@ -31,7 +31,7 @@
         class="w-full"
         @click="submitTag"
       >
-        Confirm
+        {{ __("Confirm") }}
       </Button>
     </template>
   </Dialog>

--- a/frontend/src/components/Settings/ProfileSettings.vue
+++ b/frontend/src/components/Settings/ProfileSettings.vue
@@ -36,7 +36,7 @@
   >
     <template #body-content>
       <div class="flex flex-col items-start justify-start gap-y-2">
-        <span class="text-base text-ink-gray-5">Profile Photo</span>
+        <span class="text-base text-ink-gray-5">{{ __("Profile Photo") }}</span>
         <div class="flex items-center justify-between w-full">
           <Avatar
             :image="newImageUrl"
@@ -96,12 +96,12 @@
 
   <Switch
     v-model="singleClick"
-    label="Single click to open files and folders"
+    :label="__('Single click to open files and folders')"
     class="!px-0 hover:!bg-inherit"
   />
   <Switch
     v-model="detectLinks"
-    label="Automatically detect links"
+    :label="__('Automatically detect links')"
     class="!px-0 hover:!bg-inherit"
   />
 </template>

--- a/frontend/src/components/Settings/SettingsDialog.vue
+++ b/frontend/src/components/Settings/SettingsDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <Dialog
     v-model="open"
-    :options="{ title: 'Settings', size: '5xl' }"
+    :options="{ title: __('Settings'), size: '5xl' }"
   >
     <template #body>
       <div

--- a/frontend/src/components/Settings/StorageSettings.vue
+++ b/frontend/src/components/Settings/StorageSettings.vue
@@ -4,9 +4,9 @@
   </h1>
 
   <div class="flex items-center justify-between w-full mb-2">
-    <span class="text-base font-medium text-ink-gray-8">{{ showFileStorage ? "You have" : "Your team has" }} used
-      {{ formatSize(usedSpace) ? formatSize(usedSpace) + " out" : "none" }} of
-      {{ showFileStorage ? "your" : "" }} {{ base2BlockSize(spaceLimit) }} ({{
+    <span class="text-base font-medium text-ink-gray-8">{{ showFileStorage ? __("You have") : __("Your team has") }} {{ __("used") }}
+      {{ formatSize(usedSpace) ? formatSize(usedSpace) + " " + __("out of") : __("none of") }}
+      {{ base2BlockSize(spaceLimit) }} ({{
         formatPercent((usedSpace / spaceLimit) * 100)
       }})</span>
     <div
@@ -78,14 +78,14 @@
     class="w-full flex flex-col items-center justify-center my-10"
   >
     <LucideCloud class="h-7 stroke-1 text-ink-gray-5" />
-    <span class="text-ink-gray-8 text-sm mt-2">No Storage Used</span>
+    <span class="text-ink-gray-8 text-sm mt-2">{{ __("No Storage Used") }}</span>
   </div>
   <div
     v-if="storageBreakdown.data?.entities?.length"
     class="mt-1 text-ink-gray-8 font-medium text-base py-2"
     :class="storageBreakdown.data?.entities?.length ? 'border-b' : ''"
   >
-    Large Files:
+    {{ __("Large Files:") }}
   </div>
   <div
     class="flex flex-col items-start justify-start w-full rounded full px-1.5 overflow-y-auto"

--- a/frontend/src/components/Settings/TagSettings.vue
+++ b/frontend/src/components/Settings/TagSettings.vue
@@ -34,14 +34,14 @@
           placement="right"
           :options="[
             {
-              label: 'Edit',
+              label: __('Edit'),
               icon: 'edit-2',
               onClick: () => {
                 showEditDialog = true
               },
             },
             {
-              label: 'Delete',
+              label: __('Delete'),
               theme: 'red',
               icon: 'trash-2',
               onClick: () => {
@@ -64,7 +64,7 @@
       class="h-full w-full flex flex-col items-center justify-center my-auto"
     >
       <LucideTag class="h-7 stroke-1 text-ink-gray-5" />
-      <span class="text-ink-gray-8 text-sm mt-2">No Tags</span>
+      <span class="text-ink-gray-8 text-sm mt-2">{{ __("No Tags") }}</span>
     </div>
   </div>
   <NewTagDialog
@@ -82,12 +82,12 @@
     v-if="showDeleteDialog"
     v-model="showDeleteDialog"
     :options="{
-      title: 'Delete Tag',
-      message: `Are you sure you want to delete the tag ${selectedTag.title}? This action cannot be undone`,
+      title: __('Delete Tag'),
+      message: __('Are you sure you want to delete this tag? This action cannot be undone'),
       size: 'sm',
       actions: [
         {
-          label: 'Confirm',
+          label: __('Confirm'),
           variant: 'subtle',
           theme: 'red',
           onClick: () => {

--- a/frontend/src/components/Settings/UserListSettings.vue
+++ b/frontend/src/components/Settings/UserListSettings.vue
@@ -57,9 +57,8 @@
     </template>
     <div class="py-1 flex justify-between">
       <div>
-        You have an invite to join
-        <span class="font-medium">{{ invite.team_name }}</span
-        >.
+        {{ __("You have an invite to join") }}
+        <span class="font-medium">{{ invite.team_name }}</span>.
       </div>
     </div>
   </Alert>
@@ -77,23 +76,23 @@
       :options="
         dynamicList([
           {
-            label: 'Edit',
+            label: __('Edit'),
             icon: LucidePencil,
             onClick: () => (showEditTeam = true),
             cond: isAdmin.data,
           },
           {
-            label: 'Sync',
+            label: __('Sync'),
             icon: LucideRefreshCcw,
             cond: isAdmin.data && teamData.s3_bucket,
             onClick: () =>
               createDialog({
-                title: 'Sync files from S3',
+                title: __('Sync files from S3'),
                 component: h(SyncBreakdown, { team }),
               }),
           },
           {
-            label: 'Leave',
+            label: __('Leave'),
             icon: LucideLogOut,
             onClick: () => leaveTeam.submit({ team }),
           },
@@ -101,7 +100,7 @@
       "
     />
     <Button
-      label="Invite"
+      :label="__('Invite')"
       :icon-left="h(LucideMail, { class: 'size-4' })"
       class="ml-auto"
       @click="showInvite = true"
@@ -111,7 +110,7 @@
     v-else
     class="text-ink-gray-8 text-center text-p-sm py-4"
   >
-    No teams yet. Create one to get started.
+    {{ __("No teams yet. Create one to get started.") }}
   </div>
   <Tabs
     v-if="team"
@@ -186,7 +185,7 @@
                 )
               }}
               <template v-if="user.name === $store.state.user.id"
-                >(you)</template
+                >({{ __("you") }})</template
               >
             </span>
           </div>
@@ -197,7 +196,7 @@
           v-if="!invites?.data || !invites.data.length"
           class="text-ink-gray-8 text-center text-p-sm py-4"
         >
-          No invites found.
+          {{ __("No invites found.") }}
         </div>
         <div
           v-for="(invite, index) in invites?.data"
@@ -214,7 +213,7 @@
                   invite.email
                 }}</span>
                 <span class="text-xs text-ink-gray-5"
-                  >Invited by
+                  >{{ __("Invited by") }}
                   <UserTooltip :email="invite.owner" />
                 </span>
               </div>
@@ -222,8 +221,8 @@
                 <Tooltip
                   :text="
                     invite.status === 'Proposed'
-                      ? 'A person from your domain has joined Drive.'
-                      : 'This invite was sent from your team.'
+                      ? __('A person from your domain has joined Drive.')
+                      : __('This invite was sent from your team.')
                   "
                 >
                   <Badge
@@ -280,7 +279,7 @@
   <Dialog
     v-model="showInvite"
     :options="{
-      title: 'Invite people to ' + teamData.title,
+      title: __('Invite people to') + ' ' + teamData.title,
       size: 'lg',
     }"
   >
@@ -307,7 +306,7 @@
               v-model="emailInput"
               type="text"
               autocomplete="off"
-              placeholder="Enter email address"
+              :placeholder="__('Enter email address')"
               class="h-7 w-full rounded border-none bg-surface-gray-2 py-1.5 pl-2 pr-2 text-base text-ink-gray-8 placeholder-ink-gray-4 transition-colors focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0"
               @keydown="isValidEmail"
               @keydown.enter.capture.stop="extractEmails"
@@ -319,12 +318,12 @@
       <Checkbox
         v-model="inviteAsGuest"
         class="mt-4 mb-2"
-        label="Invite as guest"
+        :label="__('Invite as guest')"
       />
       <Button
         class="w-full"
         variant="solid"
-        label="Send Invitation"
+        :label="__('Send Invitation')"
         :disabled="!emailTest().length && !invited.length"
         :loading="inviteUsers.loading"
         @click="
@@ -345,15 +344,15 @@
     v-if="showRemove"
     v-model="showRemove"
     :options="{
-      title: 'Are you sure?',
+      title: __('Are you sure?'),
       size: 'md',
-      message: `Removing ${selectedUser.full_name} will completely revoke their access to your team. You can always add them back using the same email ID.`,
+      message: __('Removing this user will completely revoke their access to your team. You can always add them back using the same email ID.'),
       actions: [
         {
           variant: 'solid',
           theme: 'red',
           label:
-            'I confirm that I want to remove ' + selectedUser.full_name + '.',
+            __('I confirm that I want to remove this user'),
           loading: removeUser.loading,
           onClick: () => {
             removeUser.submit({
@@ -375,7 +374,7 @@
       <div class="flex flex-col gap-4">
         <div>
           <FormLabel
-            label="Team Name:"
+            :label="__('Team Name:')"
             required
           />
           <div class="flex gap-1.5 mt-1.5">
@@ -406,15 +405,15 @@
           <FormControl
             v-model="s3Bucket"
             type="text"
-            label="S3 Bucket"
-            description="Optional - allows you to use a different bucket for this team."
+            :label="__('S3 Bucket')"
+            :description="__('Optional - allows you to use a different bucket for this team.')"
           />
           <FormControl
             v-model="prefix"
             :disabled="!s3Bucket"
             type="text"
-            label="Folder"
-            description="Optional - allows you to use a specific folder inside the bucket."
+            :label="__('Folder')"
+            :description="__('Optional - allows you to use a specific folder inside the bucket.')"
           />
         </template>
       </div>
@@ -460,13 +459,13 @@
   </Dialog>
   <Dialog
     v-model="showEditTeam"
-    :options="{ title: __('Settings - ' + teamData.title), size: 'sm' }"
+    :options="{ title: __('Settings') + ' - ' + teamData.title, size: 'sm' }"
   >
     <template #body-content>
       <div class="flex flex-col gap-4">
         <div>
           <FormLabel
-            label="Team Name:"
+            :label="__('Team Name:')"
             required
           />
           <div class="flex gap-1 mt-1.5">
@@ -496,13 +495,13 @@
             v-model="s3Bucket"
             :disabled="true"
             type="text"
-            label="S3 Bucket"
+            :label="__('S3 Bucket')"
           />
           <FormControl
             v-model="prefix"
             :disabled="true"
             type="text"
-            label="Folder"
+            :label="__('Folder')"
           />
         </template>
       </div>
@@ -644,17 +643,17 @@ const leaveTeam = createResource({
         else router.push({ name: "Home" })
       },
     })
-    toast("You have left the team.")
+    toast(__("You have left the team."))
   },
 })
 
 const tabs = [
   {
-    label: "Members",
+    label: __("Members"),
     icon: h(LucideUsers, { class: "size-4" }),
   },
   {
-    label: "Invites",
+    label: __("Invites"),
     icon: h(LucideMail, { class: "size-4" }),
   },
 ]
@@ -669,19 +668,19 @@ const updateAccess = (level) => {
 }
 const accessOptions = [
   {
-    label: "Manager",
+    label: __("Manager"),
     onClick: () => updateAccess(2),
   },
   {
-    label: "User",
+    label: __("User"),
     onClick: () => updateAccess(1),
   },
   {
-    label: "Guest",
+    label: __("Guest"),
     onClick: () => updateAccess(0),
   },
   {
-    label: "Remove",
+    label: __("Remove"),
     class: "text-ink-red-3",
     component: () =>
       h(
@@ -692,7 +691,7 @@ const accessOptions = [
           ],
           onClick: () => (showRemove.value = true),
         },
-        "Remove"
+        __("Remove")
       ),
   },
 ]
@@ -715,7 +714,7 @@ const inviteUsers = createResource({
   url: "drive.api.product.invite_users",
   onSuccess: () => {
     invites.fetch()
-    toast("Invite sent!")
+    toast(__("Invite sent!"))
   },
 })
 

--- a/frontend/src/components/ShareDialog/AccessButton.vue
+++ b/frontend/src/components/ShareDialog/AccessButton.vue
@@ -2,7 +2,7 @@
   <div class="flex gap-1">
     <Dropdown
       :button="{
-        label: shareAccess === 'editor' ? 'Can edit' : 'Can view',
+        label: shareAccess === 'editor' ? __('Can edit') : __('Can view'),
         iconRight: 'chevron-down',
         variant: 'ghost',
       }"
@@ -10,13 +10,13 @@
       :options="[
         {
           value: 'reader',
-          label: 'Can view',
+          label: __('Can view'),
           onClick: () => (shareAccess = 'reader'),
           icon: shareAccess === 'reader' && 'check',
         },
         {
           value: 'editor',
-          label: 'Can edit',
+          label: __('Can edit'),
           onClick: () => (shareAccess = 'editor'),
           icon: shareAccess === 'editor' && 'check',
         },
@@ -25,7 +25,7 @@
           hideLabel: true,
           items: [
             {
-              label: 'Remove',
+              label: __('Remove'),
               onClick: () => emit('removeAccess'),
               theme: 'red',
             },

--- a/frontend/src/components/ShareDialog/ShareDialog.vue
+++ b/frontend/src/components/ShareDialog/ShareDialog.vue
@@ -9,7 +9,7 @@
         <!-- Header -->
         <div class="flex w-full justify-between gap-x-2 mb-4">
           <div class="font-semibold text-2xl flex text-nowrap overflow-hidden">
-            Sharing "
+            {{ __("Sharing") }} "
             <div class="truncate max-w-[80%]">
               {{ entity?.title }}
             </div>
@@ -29,7 +29,7 @@
           <!-- General section -->
           <div class="mb-4 border-b pb-4">
             <div class="mb-2 text-ink-gray-5 font-medium text-base">
-              General Access
+              {{ __("General Access") }}
             </div>
             <div class="flex justify-between mt-3">
               <div class="flex flex-col gap-2">
@@ -69,7 +69,7 @@
             </div>
           </div>
           <!-- Members section -->
-          <div class="text-ink-gray-5 font-medium text-base mb-2">Members</div>
+          <div class="text-ink-gray-5 font-medium text-base mb-2">{{ __("Members") }}</div>
           <div class="flex gap-3">
             <div class="flex-grow">
               <Combobox
@@ -107,7 +107,7 @@
                       <ComboboxInput
                         ref="queryInput"
                         v-focus
-                        placeholder="Add people..."
+                        :placeholder="__('Add people...')"
                         class="text-base px-1.5 p-1 flex-shrink min-w-24 grow basis-0 border-none bg-transparent 1 text-ink-gray-8 placeholder-ink-gray-4 focus:ring-0"
                         autocomplete="off"
                         @change="query = $event.target.value"
@@ -237,9 +237,9 @@
                   v-if="user.user === entity.owner"
                   class="flex gap-1"
                 >
-                  Owner (you)
+                  {{ __("Owner (you)") }}
                 </div>
-                <template v-else>You</template>
+                <template v-else>{{ __("You") }}</template>
               </span>
               <AccessButton
                 v-else-if="user.user !== entity.owner"
@@ -267,7 +267,7 @@
                 v-else
                 class="ml-auto flex items-center gap-1 text-ink-gray-5"
               >
-                Owner
+                {{ __("Owner") }}
                 <LucideDiamond class="size-3" />
               </span>
             </div>
@@ -283,7 +283,7 @@
               <Button
                 class="text-sm"
                 variant="ghost"
-                label="Advanced"
+                :label="__('Advanced')"
                 :icon-left="h(LucideSettings, { class: 'size-4' })"
                 @click="advanced = true"
               />
@@ -297,11 +297,11 @@
                 <template #prefix>
                   <LucideLink2 class="w-4 text-ink-gray-6" />
                 </template>
-                Copy Link
+                {{ __("Copy Link") }}
               </Button>
               <Button
                 v-if="sharedUsers.length"
-                label="Invite"
+                :label="__('Invite')"
                 variant="solid"
                 @click="addShares"
               />
@@ -311,16 +311,16 @@
         <div v-else>
           <div
             class="flex text-sm gap-1 items-center mb-3 cursor-pointer"
-            label="Back"
+            :label="__('Back')"
             @click="advanced = false"
           >
             <LucideArrowLeft class="size-4" />
-            Back
+            {{ __("Back") }}
           </div>
 
           <Switch
             v-model="allowDownload"
-            label="Allow download"
+            :label="__('Allow download')"
           />
         </div>
       </div>
@@ -384,29 +384,29 @@ allUsers.fetch({ team: "all" })
 
 const levelOptions = [
   {
-    label: "Accessible to invited members",
+    label: __("Accessible to invited members"),
     value: "restricted",
     icon: markRaw(LucideLock),
   },
   {
-    label: "Accessible to a team",
+    label: __("Accessible to a team"),
     value: "team",
     icon: markRaw(LucideBuilding2),
   },
-  { label: "Accessible to all", value: "public", icon: markRaw(LucideGlobe2) },
+  { label: __("Accessible to all"), value: "public", icon: markRaw(LucideGlobe2) },
 ]
 const accessOptions = computed(() =>
   dynamicList([
-    { value: "reader", label: "Can view", icon: LucideEye },
+    { value: "reader", label: __("Can view"), icon: LucideEye },
     {
       value: "upload",
-      label: "Can upload",
+      label: __("Can upload"),
       cond: props.entity.is_group && props.entity.upload,
       icon: LucideUpload,
     },
     {
       value: "editor",
-      label: "Can edit",
+      label: __("Can edit"),
       cond: props.entity.write,
       icon: LucidePencil,
     },

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -4,7 +4,7 @@
     v-model:collapsed="isCollapsed"
     class="hidden sm:flex"
     :header="{
-      title: 'Drive',
+      title: __('Drive'),
       subtitle: $store.state.user.fullName,
       menuItems: settingsItems,
       logo: FrappeDriveLogo,
@@ -156,7 +156,7 @@ const settingsItems = computed(() => [
       },
       {
         icon: LucideMoon,
-        label: "Toggle theme",
+        label: __("Toggle theme"),
         onClick: toggleTheme,
       },
     ],
@@ -218,31 +218,31 @@ const sidebarItems = computed(() => {
       ],
     },
     {
-      label: "Drive",
+      label: __("Drive"),
       items: [
         {
-          label: "Home",
+          label: __("Home"),
           to: `/`,
           icon: LucideHome,
           isActive: first.name == "Home",
           accessKey: "h",
         },
         {
-          label: "Recents",
+          label: __("Recents"),
           to: `/recents`,
           icon: LucideClock,
           isActive: first.name == "Recents",
           accessKey: "r",
         },
         {
-          label: "Shared",
+          label: __("Shared"),
           to: `/shared`,
           icon: LucideUsers,
           isActive: first.name == "Shared",
           accessKey: "s",
         },
         {
-          label: "Trash",
+          label: __("Trash"),
           to: `/trash`,
           icon: LucideTrash,
           isActive: first.name == "Trash",
@@ -250,7 +250,7 @@ const sidebarItems = computed(() => {
       ],
     },
     {
-      label: "Teams",
+      label: __("Teams"),
       cond: getTeams.data && Object.keys(getTeams.data).length > 0,
       collapsible: true,
       items:
@@ -264,25 +264,25 @@ const sidebarItems = computed(() => {
         })),
     },
     {
-      label: "Views",
+      label: __("Views"),
       collapsible: true,
       items: dynamicList([
         {
-          label: "Favourites",
+          label: __("Favourites"),
           to: `/favourites`,
           icon: LucideStar,
           isActive: first.name == "Favourites",
           accessKey: "f",
         },
         {
-          label: "Documents",
+          label: __("Documents"),
           to: `/documents`,
           icon: LucideFileText,
           isActive: first.name == "Documents",
           accessKey: "d",
         },
         {
-          label: "Slides",
+          label: __("Slides"),
           to: `/presentations`,
           icon: LucideGalleryVerticalEnd,
           isActive: first.name == "Slides",


### PR DESCRIPTION
Wrap all user-facing strings with __() function for internationalization. This enables translation of the Drive UI through PO files.

Components updated:
- Navigation: BottomBar, Sidebar, Navbar
- Dialogs: ConfirmDialog, MoveDialog, RenameDialog, NewFolderDialog, NewLinkDialog
- Settings: SettingsDialog, ProfileSettings, StorageSettings, BackendSettings, TagSettings, UserListSettings, EditTagDialog
- ShareDialog: ShareDialog, AccessButton
- DocEditor: TextEditor, VersionsSidebar, WriterSettings, NewVersionDialog
- GenericPage