### PR TITLE
refactor(toolbar): use dropdown's own switch

### DIFF
--- a/frontend/src/components/DriveToolBar.vue
+++ b/frontend/src/components/DriveToolBar.vue
@@ -278,6 +278,7 @@ const columnHeaders = [
                 label: __('Smart'),
                 disabled: sortOrder.value.field !== 'title',
                 modelValue: sortOrder.value.smart,
+                class: 'px-2',
                 'onUpdate:modelValue': (val) => (sortOrder.value.smart = val),
               })
           },

--- a/frontend/src/components/DriveToolBar.vue
+++ b/frontend/src/components/DriveToolBar.vue
@@ -232,20 +232,11 @@ onKeyDown('Escape', () => {
   search.value = ''
 })
 
-const orderByItems = computed(() => {
-  return columnHeaders.map((header) => ({
-    ...header,
-    onClick: () => {
-      sortOrder.value.field = header.field
-      sortOrder.value.label = header.label
-    },
-  }))
-})
 const toggleAscending = () => {
   sortOrder.value.ascending = !sortOrder.value.ascending
 }
 
-const columnHeaders = [
+const columnHeaders = computed(() => [
   {
     label: __('Name'),
     field: 'title',
@@ -271,20 +262,23 @@ const columnHeaders = [
     hideLabel: true,
     items: [
       {
-        component: defineComponent({
-          setup() {
-            return () =>
-              h(Switch, {
-                label: __('Smart'),
-                disabled: sortOrder.value.field !== 'title',
-                modelValue: sortOrder.value.smart,
-                class: 'px-2',
-                'onUpdate:modelValue': (val) => (sortOrder.value.smart = val),
-              })
-          },
-        }),
+        label: __('Smart'),
+        disabled: sortOrder.value.field !== 'title',
+        switch: true,
+        switchValue: sortOrder.value.smart,
+        onClick: (val) => (sortOrder.value.smart = val),
       },
     ],
   },
-]
+])
+
+const orderByItems = computed(() => {
+  return columnHeaders.value.map((header) => ({
+    ...header,
+    onClick: () => {
+      sortOrder.value.field = header.field
+      sortOrder.value.label = header.label
+    },
+  }))
+})
 </script>


### PR DESCRIPTION
## Before
<img width="324" height="83" alt="image" src="https://github.com/user-attachments/assets/29fba25e-8127-4a3f-b2da-528a434f4af0" />

## After

https://github.com/user-attachments/assets/2a875f81-ce15-400d-bebe-2e0df3b3d0e8


related https://github.com/frappe/frappe-ui/pull/580