### PR TITLE
fix(Drive Team): KeyError when session user casing differs from team members

### DIFF
--- a/drive/api/permissions.py
+++ b/drive/api/permissions.py
@@ -112,14 +112,30 @@ def is_admin(team: str):
     if frappe.session.user == "Administrator":
         return True
     drive_team = {k.user: k for k in frappe.get_doc("Drive Team", team).users}
-    return drive_team[frappe.session.user].access_level == 2
+    member = get_team_member_row(drive_team, frappe.session.user)
+    return bool(member and member.access_level == 2)
 
 
 def get_access_level(team, user=None):
     if not user:
         user = frappe.session.user
     drive_team = {k.user: k for k in frappe.get_doc("Drive Team", team).users}
-    return drive_team[user].access_level
+    member = get_team_member_row(drive_team, user)
+    if not member:
+        return 0
+    return member.access_level
+
+
+def get_team_member_row(users_by_name: dict, user: str):
+    """Resolve a team member row; session *user* can differ in case from Link values in the child table."""
+    row = users_by_name.get(user)
+    if row is not None:
+        return row
+    key_cf = user.casefold()
+    for key, row in users_by_name.items():
+        if key.casefold() == key_cf:
+            return row
+    return None
 
 
 @frappe.whitelist()

--- a/drive/api/product.py
+++ b/drive/api/product.py
@@ -4,7 +4,7 @@ from frappe.rate_limiter import rate_limit
 from frappe.translate import get_all_translations
 from frappe.utils import escape_html, split_emails, validate_email_address
 
-from drive.api.permissions import get_teams, is_admin
+from drive.api.permissions import get_team_member_row, get_teams, is_admin
 from drive.utils import default_team
 
 
@@ -60,10 +60,11 @@ def edit_team(team: str, icon: str = None, team_name: str = None):
 def leave_team(team: str):
     user = frappe.session.user
     drive_team = {k.user: k for k in frappe.get_doc("Drive Team", team).users}
-    if user not in drive_team:
+    member = get_team_member_row(drive_team, user)
+    if not member:
         frappe.throw("User doesn't belong to team")
 
-    frappe.delete_doc("Drive Team Member", drive_team[user].name)
+    frappe.delete_doc("Drive Team Member", member.name)
 
 
 @frappe.whitelist()
@@ -300,8 +301,11 @@ def set_user_access(team: str, user: str, access_level: int):
     if not is_admin(team):
         frappe.throw("You don't have the permissions for this action.")
     drive_team = {k.user: k for k in frappe.get_doc("Drive Team", team).users}
-    drive_team[user].access_level = access_level
-    drive_team[user].save()
+    member = get_team_member_row(drive_team, user)
+    if not member:
+        frappe.throw("User doesn't belong to team")
+    member.access_level = access_level
+    member.save()
 
 
 @frappe.whitelist()
@@ -309,9 +313,12 @@ def remove_user(team: str, user_id: str):
     if not is_admin(team) or user_id == frappe.session.user:
         frappe.throw("You don't have the permissions for this action.")
     drive_team = {k.user: k for k in frappe.get_doc("Drive Team", team).users}
-    if frappe.session.user not in drive_team:
+    if not get_team_member_row(drive_team, frappe.session.user):
         frappe.throw("User doesn't belong to team")
-    frappe.delete_doc("Drive Team Member", drive_team[user_id].name)
+    target = get_team_member_row(drive_team, user_id)
+    if not target:
+        frappe.throw("User doesn't belong to team")
+    frappe.delete_doc("Drive Team Member", target.name)
 
 
 # SECURITY: send user data with files


### PR DESCRIPTION
## Problem
When users tried to open a **Drive Team**, they got a server error and following **Error Log** was created:

```
Traceback with variables (most recent call last):
  File "apps/frappe/frappe/app.py", line 120, in application
    response = frappe.api.handle(request)
      request = <Request 'https://service.example.com/api/method/drive.api.list.files?team=h7ohp1a1r9&order_by=modified+0&personal=0' [GET]>
      response = None
      rollback = True
      e = KeyError('user@example.com')
  File "apps/frappe/frappe/api/__init__.py", line 52, in handle
    data = endpoint(**arguments)
      request = <Request 'https://service.example.com/api/method/drive.api.list.files?team=h7ohp1a1r9&order_by=modified+0&personal=0' [GET]>
      endpoint = <function handle_rpc_call at 0x7a2dc7d76f20>
      arguments = {'method': 'drive.api.list.files'}
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
      method = 'drive.api.list.files'
      frappe = <module 'frappe' from 'apps/frappe/frappe/__init__.py'>
  File "apps/frappe/frappe/handler.py", line 53, in handle
    data = execute_cmd(cmd)
      cmd = 'drive.api.list.files'
      data = None
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
      cmd = 'drive.api.list.files'
      from_async = False
      server_script = None
      method = <function files at 0x7a2da9513880>
  File "apps/frappe/frappe/__init__.py", line 1758, in call
    return fn(*args, **newargs)
      fn = <function files at 0x7a2da9513880>
      args = ()
      kwargs = {'team': 'h7ohp1a1r9', 'order_by': 'modified 0', 'personal': '0', 'cmd': 'drive.api.list.files'}
      newargs = {'team': 'h7ohp1a1r9', 'order_by': 'modified 0'}
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
      args = ()
      kwargs = {'team': 'h7ohp1a1r9', 'order_by': 'modified 0'}
      apply_condition = <function whitelist.<locals>.innerfn.<locals>.<lambda> at 0x7a2da9511440>
      func = <function files at 0x7a2da9510900>
  File "apps/drive/drive/utils/__init__.py", line 375, in wrapper
    return func(*args, **kwargs)
      args = ()
      kwargs = {'team': 'h7ohp1a1r9', 'order_by': 'modified 0'}
      sig = <Signature (team, entity_name=None, order_by='modified 1', is_active=1, limit=20, cursor=None, favourites_only=0, recents_only=0, shared=None, tag_list=[], file_kinds=[], folders=0, only_parent=1, search=None)>
      bound_args = <BoundArguments (team='h7ohp1a1r9', entity_name=None, order_by='modified 0', is_active=1, limit=20, cursor=None, favourites_only=0, recents_only=0, shared=None, tag_list=[], file_kinds=[], folders=0, only_parent=1, search=None)>
      func = <function files at 0x7a2da95107c0>
  File "apps/drive/drive/api/list.py", line 73, in files
    user_access = get_user_access(entity, user)
      team = 'h7ohp1a1r9'
      entity_name = 'h7ptmos68a'
      order_by = 'modified 0'
      is_active = 1
      limit = 20
      cursor = None
      favourites_only = 0
      recents_only = 0
      shared = None
      tag_list = []
      file_kinds = []
      folders = 0
      only_parent = 1
      search = None
      field = '_modified'
      ascending = 0
      all_teams = False
      user = 'user@example.com'
      entity = <DriveFile: h7ptmos68a>
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
      args = [<DriveFile: h7ptmos68a>, 'user@example.com']
      kwargs = {}
      apply_condition = <function whitelist.<locals>.innerfn.<locals>.<lambda> at 0x7a2dad7cc9a0>
      func = <function get_user_access at 0x7a2dad7cc900>
  File "apps/drive/drive/api/permissions.py", line 73, in get_user_access
    access_level = get_access_level(entity.team)
      entity = <DriveFile: h7ptmos68a>
      user = 'user@example.com'
      team = False
      access = {'read': 0, 'comment': 0, 'share': 0, 'write': 0, 'upload': 0}
      teams = ['h7ohp1a1r9', 'oiokp03jdg']
  File "apps/drive/drive/api/permissions.py", line 114, in get_access_level
    return drive_team[frappe.session.user].access_level
      team = 'h7ohp1a1r9'
      drive_team = {'member1@domain.com': <DriveTeamMember: tvl8knrf8m parent=h7ohp1a1r9>, 'member2@domain.com': <DriveTeamMember: tvldcd7atm parent=h7ohp1a1r9>, 'member3@domain.com': <DriveTeamMember: tvln5t5pc4 parent=h7ohp1a1r9> ... }
builtins.KeyError: 'user@example.com'
```
NOTE: I manually anonymised this **Error Log** with dummy email addresses and a dummy URL.