### PR TITLE
fix: thumbnails for presentations

### DIFF
--- a/drive/api/files.py
+++ b/drive/api/files.py
@@ -139,6 +139,7 @@ def get_thumbnail(entity_name: str):
         entity_name,
         [
             "is_group",
+            "is_link",
             "path",
             "title",
             "mime_type",
@@ -171,13 +172,14 @@ def get_thumbnail(entity_name: str):
                 html = frappe.get_value("Drive Document", drive_file.document, "raw_content")
                 thumbnail_data = html[:1000] if html else ""
             elif drive_file.mime_type == "frappe/slides":
-                # Use this until the thumbnail method is whitelisted
-                thumbnails = frappe.call(
-                    "slides.slides.doctype.presentation.presentation.get_slide_thumbnails",
-                    presentation=drive_file.path,
+                thumbnail_url = frappe.call(
+                    "slides.slides.doctype.presentation.presentation.get_presentation_thumbnail",
+                    presentation_name=drive_file.path,
                 )
+                if not thumbnail_url:
+                    return ""
                 frappe.local.response["type"] = "redirect"
-                frappe.local.response["location"] = thumbnails[0]
+                frappe.local.response["location"] = thumbnail_url
                 return
             else:
                 thumbnail = manager.get_thumbnail(drive_file.team, entity_name)

--- a/frontend/src/components/GridItem.vue
+++ b/frontend/src/components/GridItem.vue
@@ -70,7 +70,7 @@ import { createResource } from "frappe-ui"
 import { ref, computed } from "vue"
 const props = defineProps({ file: Object })
 
-const [thumbnailLink, backupLink, is_image] = getThumbnailUrl(props.file)
+const [thumbnailLink, backupLink, is_image] = getThumbnailUrl(props.file, "grid")
 const src = ref(thumbnailLink || backupLink)
 const imgLoaded = ref(false)
 

--- a/frontend/src/utils/getIconUrl.js
+++ b/frontend/src/utils/getIconUrl.js
@@ -3,19 +3,16 @@ export function getIconUrl(file_type) {
 }
 
 export function getThumbnailUrl({ name, file_type, thumbnail, external }, view = 'list') {
-  // Currently only Slides
-  if (external) return [thumbnail, getIconUrl("presentation"), false]
+  const iconURL = getIconUrl(file_type?.toLowerCase() ?? "presentation")
+  const showThumbnail = view !== 'list'
+
+  if (external) return [showThumbnail ? thumbnail : null, iconURL, !showThumbnail]
+
   const HTML_THUMBNAILS = ["Markdown", "Code", "Text", "Document"]
-  const IMAGE_THUMBNAILS = view === "list"
-    ? ["Image", "Video", "PDF"]
-    : ["Image", "Video", "PDF", "Presentation"]
+  const IMAGE_THUMBNAILS = showThumbnail ? ["Image", "Video", "PDF", "Presentation"] : ["Image", "Video", "PDF"]
   const is_image = IMAGE_THUMBNAILS.includes(file_type)
-  const iconURL = getIconUrl(file_type.toLowerCase())
+
   if (!is_image && !HTML_THUMBNAILS.includes(file_type))
     return [null, iconURL, true]
-  return [
-    `/api/method/drive.api.files.get_thumbnail?entity_name=${name}`,
-    iconURL,
-    is_image,
-  ]
+  return [`/api/method/drive.api.files.get_thumbnail?entity_name=${name}`, iconURL, is_image]
 }

--- a/frontend/src/utils/getIconUrl.js
+++ b/frontend/src/utils/getIconUrl.js
@@ -2,11 +2,13 @@ export function getIconUrl(file_type) {
   return `/assets/drive/images/icons/${file_type.toLowerCase()}.svg`
 }
 
-export function getThumbnailUrl({ name, file_type, thumbnail, external }) {
+export function getThumbnailUrl({ name, file_type, thumbnail, external }, view = 'list') {
   // Currently only Slides
   if (external) return [thumbnail, getIconUrl("presentation"), false]
   const HTML_THUMBNAILS = ["Markdown", "Code", "Text", "Document"]
-  const IMAGE_THUMBNAILS = ["Image", "Video", "PDF", "Presentation"]
+  const IMAGE_THUMBNAILS = view === "list"
+    ? ["Image", "Video", "PDF"]
+    : ["Image", "Video", "PDF", "Presentation"]
   const is_image = IMAGE_THUMBNAILS.includes(file_type)
   const iconURL = getIconUrl(file_type.toLowerCase())
   if (!is_image && !HTML_THUMBNAILS.includes(file_type))


### PR DESCRIPTION
### Changes
- Use new API for fetching Presentation thumbnails.
- Noticed that the List view also shows images for thumbnails when displaying Presentations. We probably should only show images in the Grid view and stick to icons for list view since images are barely visible with such small icon size.

### Screen Recording

https://github.com/user-attachments/assets/3e65252b-512f-4ac3-84dc-e197a37aa321

