### PR TITLE
Use Framework desk_theme for Drive theming

### DIFF
--- a/drive/www/drive.py
+++ b/drive/www/drive.py
@@ -7,12 +7,19 @@ no_cache = 1
 TITLES = {"login": "Login", "signup": "Create an Account"}
 
 
+def get_desk_theme():
+    if frappe.session.user == "Guest":
+        return "Light"
+    return frappe.get_cached_value("User", frappe.session.user, "desk_theme") or "Light"
+
+
 def get_context():
     csrf_token = frappe.sessions.get_csrf_token()
     frappe.db.commit()
     context = frappe._dict()
     context.boot = get_boot()
     context.boot.csrf_token = csrf_token
+    context.desk_theme = context.boot.desk_theme
     context.csrf_token = csrf_token
     context.site_name = frappe.local.site
 
@@ -56,6 +63,7 @@ def get_boot():
             "default_route": get_default_route(),
             "site_name": frappe.local.site,
             "read_only_mode": frappe.flags.read_only,
+            "desk_theme": get_desk_theme(),
         }
     )
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html
+  lang="en"
+  data-theme-mode="{{ desk_theme.lower() }}"
+  data-theme="{{ desk_theme.lower() }}"
+>
   <head>
     <meta charset="UTF-8" />
     <!-- HTML Meta Tags -->

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -71,14 +71,19 @@ import LucideGalleryVerticalEnd from '~icons/lucide/gallery-vertical-end'
 import SettingsDialog from '@/components/Settings/SettingsDialog.vue'
 import ShortcutsDialog from '@/components/ShortcutsDialog.vue'
 import emitter from '@/emitter'
-import { ref, computed, watch, onMounted, h } from 'vue'
+import { ref, computed, watch, h } from 'vue'
 import AppsIcon from '@/components/AppsIcon.vue'
 import { useRouter } from 'vue-router'
 import { move } from '@/resources/files'
 
 import LucideBook from '~icons/lucide/book'
 import LucideBadgeHelp from '~icons/lucide/badge-help'
+import LucideSunMoon from '~icons/lucide/sun-moon'
+import LucideSun from '~icons/lucide/sun'
 import LucideMoon from '~icons/lucide/moon'
+import LucideMonitor from '~icons/lucide/monitor'
+import LucideCheck from '~icons/lucide/check'
+import { getThemeMode, switchTheme } from '@/utils/setupTheme'
 
 defineEmits(['toggleMobileSidebar', 'showSearchPopUp'])
 const store = useStore()
@@ -109,6 +114,13 @@ emitter.on('showSettings', (val = 0) => {
 emitter.on('toggleShortcuts', () => {
   showShortcuts.value = !showShortcuts.value
 })
+
+const themeMode = ref(getThemeMode())
+
+function selectTheme(theme) {
+  switchTheme(theme)
+  themeMode.value = theme.toLowerCase()
+}
 
 const settingsItems = computed(() => [
   {
@@ -150,9 +162,25 @@ const settingsItems = computed(() => [
         onClick: () => window.open('https://t.me/frappedrive', '_blank'),
       },
       {
-        icon: LucideMoon,
-        label: 'Toggle theme',
-        onClick: toggleTheme,
+        icon: LucideSunMoon,
+        label: __('Theme'),
+        submenu: [
+          {
+            label: __('Light'),
+            icon: themeMode.value === 'light' ? LucideCheck : LucideSun,
+            onClick: () => selectTheme('Light'),
+          },
+          {
+            label: __('Dark'),
+            icon: themeMode.value === 'dark' ? LucideCheck : LucideMoon,
+            onClick: () => selectTheme('Dark'),
+          },
+          {
+            label: __('Automatic'),
+            icon: themeMode.value === 'automatic' ? LucideCheck : LucideMonitor,
+            onClick: () => selectTheme('Automatic'),
+          },
+        ],
       },
     ],
   },
@@ -173,20 +201,6 @@ const settingsItems = computed(() => [
     ],
   },
 ])
-
-function toggleTheme() {
-  const currentTheme = document.documentElement.getAttribute('data-theme')
-  const theme = currentTheme === 'dark' ? 'light' : 'dark'
-  document.documentElement.setAttribute('data-theme', theme)
-  localStorage.setItem('theme', theme)
-}
-
-onMounted(() => {
-  const theme = localStorage.getItem('theme')
-  if (['light', 'dark'].includes(theme)) {
-    document.documentElement.setAttribute('data-theme', theme)
-  }
-})
 
 function logout() {
   store.dispatch('logout')

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -20,6 +20,11 @@ html {
   scrollbar-width: auto;
 }
 
+html.theme-switching,
+html.theme-switching * {
+  transition: none !important;
+}
+
 *::-webkit-scrollbar-thumb {
   background: #c0c6cc;
   border-radius: 6px;

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -16,6 +16,7 @@ import './index.css'
 import { initSocket } from './socket'
 import focusDirective from './utils/focus'
 import translation from './translation'
+import { setupTheme } from './utils/setupTheme'
 
 const app = createApp(App)
 setConfig('resourceFetcher', frappeRequest)
@@ -47,4 +48,4 @@ setConfig('resourceFetcher', (options) => {
 app.component('FormControl', FormControl)
 app.component('Button', Button)
 
-app.mount('#app')
+setupTheme().then(() => app.mount('#app'))

--- a/frontend/src/utils/setupTheme.js
+++ b/frontend/src/utils/setupTheme.js
@@ -1,0 +1,62 @@
+import { frappeRequest } from 'frappe-ui'
+import store from '@/store'
+
+const systemTheme = window.matchMedia('(prefers-color-scheme: dark)')
+
+export function getThemeMode() {
+  return document.documentElement.getAttribute('data-theme-mode') || 'light'
+}
+
+function resolveTheme(mode) {
+  const preference = mode.toLowerCase()
+  if (preference === 'automatic') {
+    return systemTheme.matches ? 'dark' : 'light'
+  }
+  return preference
+}
+
+function applyTheme(mode) {
+  const root = document.documentElement
+  const preference = mode.toLowerCase()
+  const resolved = resolveTheme(preference)
+
+  root.classList.add('theme-switching')
+  root.style.colorScheme = resolved
+  root.setAttribute('data-theme', resolved)
+  root.setAttribute('data-theme-mode', preference)
+
+  requestAnimationFrame(() => {
+    root.classList.remove('theme-switching')
+  })
+}
+
+export async function setupTheme() {
+  if (import.meta.env.DEV) {
+    if (store.getters.isLoggedIn) {
+      const boot = await frappeRequest({
+        url: 'drive.www.drive.get_context_for_dev',
+        method: 'POST',
+      })
+      applyTheme(boot?.desk_theme || 'Light')
+    } else {
+      applyTheme('Light')
+    }
+  } else {
+    applyTheme(getThemeMode())
+  }
+
+  systemTheme.addEventListener('change', () => {
+    if (getThemeMode() === 'automatic') applyTheme('automatic')
+  })
+}
+
+export function switchTheme(theme) {
+  applyTheme(theme)
+
+  if (store.getters.isLoggedIn) {
+    frappeRequest({
+      url: 'frappe.core.doctype.user.user.switch_theme',
+      params: { theme },
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- Drive theme now follows `User.desk_theme` (Light / Dark / Automatic), synced with Desk
- Adds `Automatic` theme
- Replaces the localStorage toggle with a theme submenu that persists via Framework's `switch_theme`

There was also a weird "flash" when you changed the theme in Drive - this is solved by adding a `theme-switching` classes that stops transitions from applying during the shift.

