### PR TITLE
Replace raw Tailwind colors with semantic tokens

### DIFF
--- a/frontend/src/components/ColorPicker.vue
+++ b/frontend/src/components/ColorPicker.vue
@@ -18,7 +18,7 @@
       />
     </template>
     <template #body>
-      <div ref="colorPicker" class="rounded-lg bg-surface-white p-3 shadow-lg dark:bg-zinc-900">
+      <div ref="colorPicker" class="rounded-lg bg-surface-white p-3 shadow-lg">
         <div
           ref="colorMap"
           :style="{
@@ -91,7 +91,7 @@
             />
             <svg
               v-if="isSupported"
-              class="text-ink-gray-7 dark:text-zinc-300"
+              class="text-ink-gray-7"
               xmlns="http://www.w3.org/2000/svg"
               width="16"
               height="16"

--- a/frontend/src/components/ContextMenu.vue
+++ b/frontend/src/components/ContextMenu.vue
@@ -29,7 +29,7 @@
         <component
           :is="item.icon"
           class="mr-2 size-4 flex-shrink-0"
-          :class="item.theme ? 'text-[#E03636]' : 'text-ink-gray-7'"
+          :class="item.theme ? 'text-ink-red-3' : 'text-ink-gray-7'"
         />
         <span class="whitespace-nowrap" :class="item.theme ? 'text-ink-red-4' : 'text-ink-gray-7'">
           {{ item.label }}

--- a/frontend/src/components/CustomListRowItem.vue
+++ b/frontend/src/components/CustomListRowItem.vue
@@ -36,7 +36,7 @@
           name="star"
           width="16"
           height="16"
-          class="my-auto stroke-amber-500 fill-amber-500"
+          class="my-auto text-ink-amber-3 stroke-current fill-current"
         />
         <component :is="column.suffix({ row })" v-if="column.suffix" />
       </div>

--- a/frontend/src/components/DriveToolBar.vue
+++ b/frontend/src/components/DriveToolBar.vue
@@ -59,7 +59,7 @@
           }" :disabled placement="right" />
         <Dropdown v-if="$route.name !== 'Recents'" :options="orderByItems" placement="right">
           <div class="flex items-center whitespace-nowrap">
-            <Button class="text-sm h-7 border-r border-slate-200 rounded-r-none" :disabled
+            <Button class="text-sm h-7 border-r border-outline-gray-2 rounded-r-none" :disabled
               @click.stop="toggleAscending">
               <template #icon>
                 <LucideArrowDownAz v-if="sortOrder.ascending" class="size-4" />

--- a/frontend/src/components/FileRender.vue
+++ b/frontend/src/components/FileRender.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="error"
-    class="max-w-[450px] h-fit self-center p-10 dark:border dark:border-ink-white bg-surface-white rounded-md text-neutral-100 text-xl text-center font-medium shadow-xl flex flex-col justify-center items-center gap-4"
+    class="max-w-[450px] h-fit self-center p-10 border border-outline-gray-2 bg-surface-white rounded-md text-xl text-center font-medium shadow-xl flex flex-col justify-center items-center gap-4"
   >
     <LucideAlertCircle class="size-8 text-ink-gray-8" />
     <span class="text-ink-gray-9">Cannot open file</span>

--- a/frontend/src/components/FileTypePreview/MSOfficePreview.vue
+++ b/frontend/src/components/FileTypePreview/MSOfficePreview.vue
@@ -9,7 +9,7 @@
   >
   <div
     v-else
-    class="max-w-[450px] h-fit self-center p-10 bg-surface-white rounded-md text-neutral-100 text-xl text-center font-medium shadow-xl flex flex-col justify-center items-center gap-4"
+    class="max-w-[450px] h-fit self-center p-10 bg-surface-white rounded-md text-xl text-center font-medium shadow-xl flex flex-col justify-center items-center gap-4"
   >
     <div v-if="error" class="text-p-base">
       <LucideSettings class="size-8 mb-6 mx-auto" />

--- a/frontend/src/components/FileTypePreview/PDFPreview.vue
+++ b/frontend/src/components/FileTypePreview/PDFPreview.vue
@@ -17,7 +17,7 @@
         :scale
         :text-layer="true"
       >
-        <LoadingIndicator class="w-10 text-neutral-100 mx-auto h-full" />
+        <LoadingIndicator class="w-10 text-ink-gray-8 mx-auto h-full" />
       </VuePDF>
     </div>
     <div v-if="pages" class="flex gap-2 justify-center items-center">

--- a/frontend/src/components/GenericPage.vue
+++ b/frontend/src/components/GenericPage.vue
@@ -398,7 +398,7 @@ const actionItems = computed(() => {
       {
         label: __('Unfavourite'),
         icon: LucideStar,
-        class: 'stroke-amber-500 fill-amber-500',
+        class: 'text-ink-amber-3 stroke-current fill-current',
         action: (entities) => {
           entities.forEach((e) => (e.is_favourite = false))
           props.getEntities.setData(props.getEntities.data)

--- a/frontend/src/components/GridItem.vue
+++ b/frontend/src/components/GridItem.vue
@@ -34,7 +34,7 @@
     </div>
   </div>
   <div
-    class="p-2 h-[35%] border-t border-gray-100 flex flex-col justify-evenly"
+    class="p-2 h-[35%] border-t border-outline-gray-1 flex flex-col justify-evenly"
   >
     <div class="truncate w-full w-fit text-base font-medium text-ink-gray-8">
       {{ file.file_name }}

--- a/frontend/src/components/GridView.vue
+++ b/frontend/src/components/GridView.vue
@@ -40,7 +40,7 @@
     >
       <LucideStar
         v-if="$route.name !== 'Favourites' && file.is_favourite"
-        class="stroke-amber-500 fill-amber-500 absolute top-2 left-2 h-4"
+        class="text-ink-amber-3 stroke-current fill-current absolute top-2 left-2 h-4"
         width="16"
         height="16"
       />

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -27,7 +27,7 @@
         v-if="rootEntity?.is_favourite"
         width="16"
         height="16"
-        class="my-auto stroke-amber-500 fill-amber-500"
+        class="my-auto text-ink-amber-3 stroke-current fill-current"
       />
       <template v-if="!isLoggedIn && !inIframe">
         <Button variant="outline" @click="$router.push({ name: 'Login' })"> Sign In </Button>
@@ -239,7 +239,7 @@ const defaultActions = computed(() => {
         {
           label: __('Unfavourite'),
           icon: LucideStar,
-          color: 'stroke-amber-500 fill-amber-500',
+          color: 'text-ink-amber-3 stroke-current fill-current',
           onClick: () => {
             rootEntity.value.is_favourite = false
             toggleFav.submit({

--- a/frontend/src/components/ProgressRing.vue
+++ b/frontend/src/components/ProgressRing.vue
@@ -39,7 +39,7 @@ export default {
     },
     primaryClass: {
       type: String,
-      default: 'text-black',
+      default: 'text-ink-gray-9',
     },
     secondaryClass: {
       type: String,

--- a/frontend/src/components/Settings/TemplateSettings.vue
+++ b/frontend/src/components/Settings/TemplateSettings.vue
@@ -53,7 +53,7 @@
             variant="ghost"
             @click="confirmDelete(template)"
           >
-            <LucideTrash2 class="size-4 text-red-600" />
+            <LucideTrash2 class="size-4 text-ink-red-3" />
           </Button>
         </div>
       </div>

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -144,7 +144,7 @@ const settingsItems = computed(() => [
               h('img', { src: app.logo, class: 'size-6' }),
               h(
                 'span',
-                { class: 'max-w-18 text-sm w-full truncate' },
+                { class: 'max-w-18 text-sm w-full truncate text-ink-gray-9' },
                 app.title
               ),
             ]

--- a/frontend/src/components/SidebarItem.vue
+++ b/frontend/src/components/SidebarItem.vue
@@ -8,7 +8,7 @@
         <Tooltip
           :text="__(label)"
           placement="right"
-          arrow-class="fill-gray-900"
+          arrow-class="fill-surface-gray-7"
           :disabled="!isCollapsed"
         >
           <slot name="icon">

--- a/frontend/src/components/UploadTracker.vue
+++ b/frontend/src/components/UploadTracker.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="text-ink-gray-8 flex flex-col items-start fixed bottom-0 right-0 m-5 w-96 z-1 rounded-2xl overflow-hidden shadow-2xl dark:border 500 bg-surface-white p-4"
+    class="text-ink-gray-8 flex flex-col items-start fixed bottom-0 right-0 m-5 w-96 z-1 rounded-2xl overflow-hidden shadow-2xl border border-outline-gray-1 bg-surface-white p-4"
   >
     <div
       class="flex items-center justify-between w-full pr-1.5"

--- a/frontend/src/pages/File.vue
+++ b/frontend/src/pages/File.vue
@@ -11,7 +11,7 @@
       >
         <LoadingIndicator
           v-if="file.loading"
-          class="w-10 h-full text-neutral-100"
+          class="w-10 h-full text-ink-gray-8"
         />
         <FileRender v-else-if="file.data" :preview-entity="file.data" />
       </div>

--- a/frontend/src/pages/Teams.vue
+++ b/frontend/src/pages/Teams.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="mx-auto w-full bg-surface-white dark:bg-surface-gray-2 px-4 py-8 mt-6 w-112 rounded-2xl p-6 md:shadow-2xl flex flex-col gap-4"
+    class="mx-auto w-full bg-surface-white px-4 py-8 mt-6 w-112 rounded-2xl p-6 md:shadow-2xl flex flex-col gap-4"
   >
     <div class="text-sm absolute top-5 right-5 flex gap-1.5 text-ink-gray-8">
       <LucideLogOut class="w-3 h-3 my-auto" />

--- a/frontend/src/utils/files.js
+++ b/frontend/src/utils/files.js
@@ -518,7 +518,7 @@ export function getLink(entity, copy = true, withDomain = true) {
     if (err.name === 'NotAllowedError') {
       toast({
         icon: 'alert-triangle',
-        iconClasses: 'text-red-700',
+        iconClasses: 'text-ink-red-3',
         title: 'Clipboard permission denied',
         position: 'bottom-right',
       })


### PR DESCRIPTION
## Summary
- Replace raw Tailwind palette classes (`text-neutral-*`, `text-red-*`, `border-gray-*`, `dark:*` overrides, etc.) with frappe-ui semantic tokens
- Fixes unreadable Apps submenu text in dark mode


Made with [Cursor](https://cursor.com)