### PR TITLE
fix: align disk settings auth with DocType permissions

### DIFF
--- a/drive/api/product.py
+++ b/drive/api/product.py
@@ -364,8 +364,6 @@ def get_translations():
 
 
 def is_drive_site_admin():
-    if frappe.session.user == "Administrator":
-        return True
     return frappe.has_permission("Drive Disk Settings", "write")
 
 

--- a/drive/api/product.py
+++ b/drive/api/product.py
@@ -363,15 +363,21 @@ def get_translations():
     return get_all_translations(language)
 
 
+def is_drive_site_admin():
+    if frappe.session.user == "Administrator":
+        return True
+    return frappe.has_permission("Drive Disk Settings", "write")
+
+
 @frappe.whitelist()
 def is_site_admin():
-    return {"is_admin": "Drive Admin" in frappe.get_roles()}
+    return {"is_admin": is_drive_site_admin()}
 
 
 @frappe.whitelist(allow_guest=True)
 def disk_settings(**kwargs):
     settings = frappe.get_single("Drive Disk Settings")
-    if not is_site_admin()["is_admin"]:
+    if not is_drive_site_admin():
         # Return only safe values
         return {"preview_size": settings.preview_size, "enabled": settings.enabled}
 

--- a/drive/drive/doctype/drive_disk_settings/drive_disk_settings.json
+++ b/drive/drive/doctype/drive_disk_settings/drive_disk_settings.json
@@ -6,7 +6,6 @@
  "engine": "InnoDB",
  "field_order": [
   "general_section",
-  "jwt_key",
   "preview_size",
   "use_drive_for_files",
   "disk_section",
@@ -86,12 +85,6 @@
    "label": "Thumbnail prefix"
   },
   {
-   "fieldname": "jwt_key",
-   "fieldtype": "Data",
-   "label": "JWT Key",
-   "options": "Dangerous - if leaked, all files can be accessed."
-  },
-  {
    "default": "100",
    "description": "Used to configure maximum file sizes of in-browser previews (in megabytes).",
    "fieldname": "preview_size",
@@ -129,12 +122,22 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-03-06 14:48:40.048946",
+ "modified": "2026-06-16 18:24:47.598513",
  "modified_by": "Administrator",
  "module": "Drive",
  "name": "Drive Disk Settings",
  "owner": "Administrator",
  "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Drive Admin",
+   "share": 1,
+   "write": 1
+  },
   {
    "create": 1,
    "delete": 1,


### PR DESCRIPTION
## Summary
- Remove unused `jwt_key` from Drive Disk Settings (file auth uses `Drive Token` instead).
- Grant `Drive Admin` read/write on the Drive Disk Settings single DocType.
- Add `is_drive_site_admin()` so `disk_settings` and `is_site_admin` check `Administrator` or `has_permission("Drive Disk Settings", "write")`, keeping API access aligned with DocType permissions.

## Test plan
- [ ] Run `bench migrate` on an existing site and confirm `jwt_key` column is dropped
- [ ] As a guest/unauthenticated user, GET `disk_settings` returns only `preview_size` and `enabled`
- [ ] As `Administrator`, Storage settings tab is visible and PUT saves successfully
- [ ] As `System Manager`, Storage settings tab is visible and PUT saves successfully
- [ ] As a user with `Drive Admin` role, Storage settings tab is visible and PUT saves successfully
- [ ] As a regular Drive user without write permission, Storage settings tab is hidden and PUT does not update settings


Made with [Cursor](https://cursor.com)